### PR TITLE
シーケンス生成条件を厳しくして、文字型のカラムにシーケンスが張られたりしないようにした

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/db/beans/Column.java
+++ b/src/main/java/jp/co/tis/gsp/tools/db/beans/Column.java
@@ -16,12 +16,14 @@
 
 package jp.co.tis.gsp.tools.db.beans;
 
+import org.apache.commons.lang.StringUtils;
+
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-
-import org.apache.commons.lang.StringUtils;
+import java.util.Arrays;
+import java.util.List;
 
 @XmlRootElement(name="ATTR")
 public class Column {
@@ -72,9 +74,35 @@ public class Column {
 
     public Boolean isAutoIncrement() {
         return StringUtils.equalsIgnoreCase(defaultValue, "AUTO_INCREMENT")
-                || isSingularPrimaryKey();
-
+                || (isSingularPrimaryKey() && isNumericDataType());
     }
+
+	private Boolean isNumericDataType() {
+		// 重複は削除してもたいしたパフォーマンス向上にならないうえ、
+		// 後々のメンテナンス性が著しく下がると思われるため放置する。
+		List<String> numericDataTypeList = Arrays.asList(
+				// Oracle
+				"INTEGER", "SHORTINTEGER", "LONGINTEGER", "DECIMAL", "SHORTDECIMAL", "NUMBER",
+				// Postgres
+				"smallint", "integer", "bigint", "decimal", "numeric", "real",
+				"double precision", "smallserial", "serial", "bigserial",
+				// DB2
+				"BIGINT", "SMALLINT", "INTEGER", "DOUBLE", "NUMERIC", "REAL",
+				// H2Database
+				"INT", "INTEGER", "MEDIUMINT", "INT4", "SIGNED",
+				"TINYINT", "SMALLINT", "INT2", "YEAR", "BIGINT",
+				"INT8", "IDENTITY", "DECIMAL", "NUMBER", "DEC",
+				"NUMERIC", "DOUBLE", "DOUBLE PRECISION", "FLOAT",
+				"FLOAT8", "REAL", "FLOAT4",
+				// SQL Server
+				"bigint", "bit", "decimal", "int", "money", "numeric",
+				"smallint", "smallmoney", "tinyint", "float", "real",
+				// MySQL
+				"INTEGER", "SMALLINT", "DECIMAL", "NUMERIC", "FLOAT", "REAL",
+				"DOUBLE PRECISION", "INT", "DEC", "FIXED", "DOUBLE", "BIT"
+		);
+		return numericDataTypeList.contains(dataType);
+	}
 
     public String getGeneratorKeyName() {
         if (isSingularPrimaryKey()) {


### PR DESCRIPTION
### 修正内容

今までDDLにシーケンス生成文が書き込まれる条件は

- ObjectBrowserの「デフォルト値」列に`AUTO_INCREMENT`と記載されている
- または単一主キー

のみでした。

これに

- 単一主キーの場合はデータ型が数値型である

という条件を追加しました。

エンティティ生成時の`@SequenceGenerator`アノテーション付与は別の情報から判断されていたので修正の必要がありませんでした。