### PR TITLE
DialectFactory.getDialect()のメソッドシグニチャ変更に伴うEntityDependencyParser.pars…

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/db/EntityDependencyParser.java
+++ b/src/main/java/jp/co/tis/gsp/tools/db/EntityDependencyParser.java
@@ -30,18 +30,14 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 
 import jp.co.tis.gsp.tools.GspToolsException;
-import jp.co.tis.gsp.tools.dba.dialect.Dialect;
-import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
 
 
 public class EntityDependencyParser {
     private Map<String, Table> tableMap = new HashMap<String, Table>();
 
-    public void parse(Connection conn, String url, String schema, String driver) {
+    public void parse(Connection conn, String url, String normalizedSchemaName) {
         try {
             DatabaseMetaData metaData = conn.getMetaData();
-            Dialect dialect = DialectFactory.getDialect(url, driver);
-            String normalizedSchemaName = dialect.normalizeSchemaName(schema);
             List<String> tableNames = getAllTableNames(metaData, normalizedSchemaName);
             for (String tableName : tableNames) {
                 parseReference(metaData, normalizedSchemaName, tableName);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -102,7 +102,7 @@ public class SqlserverDialect extends Dialect {
             
             // 依存関係を考慮し削除するテーブルをソートする
             EntityDependencyParser parser = new EntityDependencyParser();
-            parser.parse(conn, url, schema, driver);
+            parser.parse(conn, url, normalizeSchemaName(schema));
             final List<String> tableList = parser.getTableList();
             Collections.reverse(tableList);
             for (String table : tableList) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/LoadDataMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/LoadDataMojo.java
@@ -92,7 +92,7 @@ public class LoadDataMojo extends AbstractDbaMojo {
 		// 依存関係を考慮し読み込むファイル順をソートする
 		EntityDependencyParser parser = new EntityDependencyParser();
 		Dialect dialect = DialectFactory.getDialect(url, driver);
-		parser.parse(conn, url, dialect.normalizeSchemaName(schema), driver);
+		parser.parse(conn, url, dialect.normalizeSchemaName(schema));
 		final List<String> tableList = parser.getTableList();
 		Collections.sort(files, new Comparator<File>() {
 			@Override


### PR DESCRIPTION
…e()で必要になった引数driverを除去するため、DialectFactoryへの依存を除去。同クラスの他のメソッドもnormalizedSchemaNameを受け取っていたため統一する意味もあり。