### PR TITLE
@TableGeneratorが使われることはないため、削除

### DIFF
--- a/recipe/spec-generatedEntity.md
+++ b/recipe/spec-generatedEntity.md
@@ -20,7 +20,6 @@ generate-entity時に生成されるエンティティで使用されるアノ�
 |@Id | 主キーであることを表します。|
 |@GeneratedValue|DBによって自動採番されることを表します。<br/>属性は以下の通り<br/>・generator:使用するジェネレータ。<br/>・strategy:主キーの値を生成する方法|
 | @SequenceGenerator|主キーを作成するシーケンスジェネレータの設定を表します。<br/>@GeneratedValueと同時に使用する必要があります。<br/>属性は以下の通り<br/>・name:このジェネレータを識別するための名前。@GeneratedValueのgeneratorに指定する。<br/>・sequenceName:使用するデータベースシーケンスオブジェクトの名前<br/>・initialValue:主キーの値の初期値<br/>・allocationSize:割り当てる際にキャッシュしておく値の範囲|
-|@TableGenerator|主キーを作成するジェネレータの設定を表します。<br/>@GeneratedValueと同時に使用する必要があります。<br/>属性は以下の通り<br/>・name:このジェネレータを識別するための名前。@GeneratedValueのgeneratorに指定する。<br/>・initialValue:主キーの値の初期値<br/>・allocationSize:割り当てる際にキャッシュしておく値の範囲|
 |@Lob|largeオブジェクト型の永続化フィールドまたは永続化プロパティであることを表します。|
 |@Temporal|時刻を表します型（java.util.Dateおよびjava.util.Calendar）を持つ永続化プロパティまたは永続化フィールドを表します。|
 |@Version|楽観的ロック機能を使用するために用いるversionフィールドまたはversionプロパティを表します。<br/>カラム名が、正規表現で「VERSION([_]?NO)?」にマッチする場合に付与されます。|

--- a/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
+++ b/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
@@ -5,8 +5,6 @@
     @GeneratedValue(generator = "generator", strategy = GenerationType.AUTO)
       <#if attr.generationType == "SEQUENCE">
     @SequenceGenerator(name = "generator", sequenceName = "${attr.columnName}_SEQ", initialValue = ${attr.initialValue}, allocationSize = ${attr.allocationSize})
-      <#elseif attr.generationType == "TABLE">
-    @TableGenerator(name = "generator", initialValue = ${attr.initialValue}, allocationSize = ${attr.allocationSize})
       </#if>
     </#if>
   </#if>


### PR DESCRIPTION
@TableGeneratorが使われることはないため以下から削除。
・エンティティに付与されるアノテーションの説明ドキュメントから説明を削除
・エンティティ生成のテンプレートから、@TableGenerator生成の分岐を削除
