### PR TITLE
execute-ddl 処理のリファクタリング

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
@@ -79,8 +79,9 @@ public class Db2Dialect extends Dialect {
         PreparedStatement stmt = null;
         try {
             conn = DriverManager.getConnection(url, adminUser, adminPassword);
-            // 目的のスキーマがなければ何もしない
+			// 指定スキーマがいなければ作成する。
             if(!existsSchema(conn, schema)) {
+            	createSchema(schema, user, password, adminUser, adminPassword);
                 return;
             }
             // テーブル・ビューの削除
@@ -179,7 +180,7 @@ public class Db2Dialect extends Dialect {
     }
 
     @Override
-    public void grantAllToAnotherSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
+    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
     	
         Connection conn = null;
         PreparedStatement pstmt = null;
@@ -205,25 +206,13 @@ public class Db2Dialect extends Dialect {
         }
     }
 
-    @Override
-    public void createSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-    	
+    private void createSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
     	PreparedStatement  userStmt = null;
         Statement createUserStmt = null;
         Connection conn = null;
     	
         try{
 			conn = getJDBCConnection(driver, admin, adminPassword);
-	        
-	 		userStmt = conn.prepareStatement("SELECT COUNT(*) AS NUM FROM SYSCAT.SCHEMATA WHERE SCHEMANAME=?");
-			userStmt.setString(1, StringUtils.upperCase(schema));
-			ResultSet rs = userStmt.executeQuery();
-			rs.next();
-			if (rs.getInt("num") > 0) {
-				// すでにデータ流し込み対象のスキーマが存在していれば何もしない
-				return;
-			}
-	
 			createUserStmt = conn.createStatement();
 			createUserStmt.execute("CREATE SCHEMA "+ schema);
 		

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -47,11 +47,34 @@ public abstract class Dialect {
 	public abstract void exportSchema(String user, String password, String schema, File dumpFile)
 			throws MojoExecutionException;
 
+	/**
+	 * 指定したスキーマ内のオブジェクトを削除し、空のスキーマを用意します。
+	 * 
+	 * 指定したスキーマが存在しない場合はスキーマを作成します。
+	 * 
+	 * @param user
+	 * @param password
+	 * @param adminUser
+	 * @param adminPassword
+	 * @param schema
+	 * @throws MojoExecutionException
+	 */
 	public abstract void dropAll(String user, String password, String adminUser,
 			String adminPassword, String schema) throws MojoExecutionException;
 
 	public abstract void importSchema(String user, String password, String schema, File dumpFile) throws MojoExecutionException;
 
+	/**
+	 * ユーザを作成します。
+	 * 
+	 * 既にユーザが存在する場合はそのユーザを削除します。
+	 * 
+	 * @param user
+	 * @param password
+	 * @param adminUser
+	 * @param adminPassword
+	 * @throws MojoExecutionException
+	 */
 	public abstract void createUser(String user, String password, String adminUser,
 			String adminPassword) throws MojoExecutionException;
 	
@@ -70,7 +93,7 @@ public abstract class Dialect {
 	public void setDriver(String driver) {
 		this.driver = driver;
 	}
-
+	
     /**
      * ユーザ名とスキーマ名が不一致の場合、別名のスキーマに対して
      * アプリユーザが操作を行えるよう権限を付与する。
@@ -80,23 +103,7 @@ public abstract class Dialect {
      * @param user ユーザ名
      * @throws MojoExecutionException エラー
      */
-    public void grantAllToAnotherSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-        // nop
-    }
-
-    /**
-     * ユーザ名とスキーマ名が不一致の場合、別名のスキーマがもし存在しなければ作成する。
-     * デフォルトでは何もしない。
-     * @param schema スキーマ名
-     * @param user TODO
-     * @param password TODO
-     * @param admin TODO
-     * @param adminPassword TODO
-     * @param conn DBコネクション
-     * @throws SQLException SQL実行時のエラー
-     * @throws UnsupportedOperationException サポートされていない操作を行った時に出るエラー
-     */
-    public void createSchema(String schema, String user, String password, String admin, String adminPassword)  throws MojoExecutionException {
+    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
         // nop
     }
 

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -50,6 +50,9 @@ public class H2Dialect extends Dialect {
             conn = DriverManager.getConnection(url, adminUser, adminPassword);
             stmt = conn.createStatement();
             stmt.execute("DROP ALL OBJECTS");
+            
+            createSchema(schema, user, password, adminUser, adminPassword);
+            
         } catch (SQLException e) {
             throw new MojoExecutionException("DROP ALL OBJECTS 実行中にエラー", e);
         } finally {
@@ -93,7 +96,7 @@ public class H2Dialect extends Dialect {
     }
 
     @Override
-    public void grantAllToAnotherSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
+    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
     	
         Connection conn = null;
         Statement stmt = null;
@@ -127,8 +130,7 @@ public class H2Dialect extends Dialect {
         }
     }
 
-    @Override
-    public void createSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
+    private void createSchema(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
         Statement stmt = null;
         Connection conn = null;
         

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -86,7 +86,7 @@ public class H2Dialect extends Dialect {
         try {
             conn = DriverManager.getConnection(url, adminUser, adminPassword);
             stmt = conn.createStatement();
-            stmt.execute("CREATE USER " + user + " PASSWORD '" + password + "'" + " ADMIN");
+            stmt.execute("CREATE USER IF NOT EXISTS " + user + " PASSWORD '" + password + "'" + " ADMIN");
         } catch (SQLException e) {
             throw new MojoExecutionException("CREATE USER 実行中にエラー: ", e);
         } finally {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -131,11 +131,6 @@ public class MysqlDialect extends Dialect {
 			if(existsUser(conn, user)) {
 				return;
 			}
-			try {
-				stmt.execute("DROP USER '"+ user + "'");
-			} catch(SQLException ignore) {
-				// DROP USERに失敗しても気にしない
-			}
 			stmt.execute("CREATE USER '"+ user + "' IDENTIFIED BY '"+ password +"'");
 		} catch (SQLException e) {
 			throw new MojoExecutionException("CREATE USER実行中にエラー", e);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -181,10 +181,9 @@ public class OracleDialect extends Dialect {
             props.put("password", adminPassword);
             conn = DriverManager.getConnection(url, props);
 			stmt = conn.createStatement();
-			try {
-				stmt.execute("DROP USER "+ user);
-			} catch(SQLException ignore) {
-				// DROP USERに失敗しても気にしない
+			
+			if(existsUser(conn, user)) {
+				return;
 			}
 
 			stmt.execute("CREATE USER "+ user + " IDENTIFIED BY "+ password + " DEFAULT TABLESPACE users");

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -284,7 +284,7 @@ public class OracleDialect extends Dialect {
 		PreparedStatement stmtMeta = null;
 		Statement stmt = null;
 		try {
-			stmtMeta = conn.prepareStatement("SELECT object_type, object_name FROM dba_objects WHERE object_type in ('TABLE', 'VIEW', 'SEQUENCE', 'PACKAGE', 'FUNCTION', 'SYNONYM') and owner = ?");
+			stmtMeta = conn.prepareStatement("SELECT object_type, object_name FROM dba_objects WHERE object_type in ('TABLE', 'VIEW', 'SEQUENCE') and owner = ?");
 			stmtMeta.setString(1, schema);
 			
 			ResultSet rsMeta = stmtMeta.executeQuery();

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -168,16 +168,12 @@ public class PostgresqlDialect extends Dialect {
         try {
             conn = DriverManager.getConnection(url, adminUser, adminPassword);
             stmt = conn.createStatement();
-            try {
-                stmt.execute("DROP OWNED BY " + role + " CASCADE");
-                stmt.execute("DROP ROLE " + role);
-            } catch(SQLException ignore) {
-                // DROP USERに失敗しても気にしない
+            if (existsUser(conn, role)) {
+            	return;
             }
             
             stmt.execute("CREATE ROLE " + role + " LOGIN PASSWORD \'" + password + "\'");
             stmt.execute("GRANT CREATE, CONNECT ON DATABASE " + database + " TO " + role);
-
         } catch (SQLException e) {
             throw new MojoExecutionException("CREATE USER実行中にエラー", e);
         } finally {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -144,11 +144,12 @@ public class SqlserverDialect extends Dialect {
         try {
             conn = DriverManager.getConnection(url, adminUser, adminPassword);
             stmt = conn.createStatement();
-            if(!existsUser(adminUser, adminPassword, user)) {
-                stmt.execute("CREATE LOGIN " + user + " WITH PASSWORD = '" + password + "'");
-                stmt.execute("CREATE USER " + user + " FOR LOGIN " + user);
-                stmt.execute("sp_addrolemember 'db_ddladmin','" + user + "'");
+            if(existsUser(adminUser, adminPassword, user)) {
+                return;
             }
+            stmt.execute("CREATE LOGIN " + user + " WITH PASSWORD = '" + password + "'");
+            stmt.execute("CREATE USER " + user + " FOR LOGIN " + user);
+            stmt.execute("sp_addrolemember 'db_ddladmin','" + user + "'");
 
         } catch (SQLException e) {
             throw new MojoExecutionException("CREATE USER実行中にエラー", e);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
@@ -69,7 +69,11 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 	protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
         DriverManagerUtil.registerDriver(driver);
 		Dialect dialect = DialectFactory.getDialect(url, driver);
+		
+		// ユーザの作成を行います
 		dialect.createUser(user, password, adminUser, adminPassword);
+		
+		// 指定スキーマ内のテーブル、ビュー、シーケンスを全て削除します。
 		dialect.dropAll(user, password, adminUser, adminPassword, schema);
 		
         FilenameFilter sqlFileFilter = new FilenameFilter() {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
@@ -16,11 +16,23 @@
 
 package jp.co.tis.gsp.tools.dba.mojo;
 
-import jp.co.tis.gsp.tools.dba.dialect.Dialect;
-import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
-import jp.co.tis.gsp.tools.dba.util.SqlSplitter;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -28,9 +40,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.seasar.framework.util.DriverManagerUtil;
 import org.seasar.framework.util.StatementUtil;
 
-import java.io.*;
-import java.sql.*;
-import java.util.*;
+import jp.co.tis.gsp.tools.dba.dialect.Dialect;
+import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
+import jp.co.tis.gsp.tools.dba.util.SqlSplitter;
 
 /**
  *
@@ -57,11 +69,9 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 	protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
         DriverManagerUtil.registerDriver(driver);
 		Dialect dialect = DialectFactory.getDialect(url, driver);
-		dialect.dropAll(user, password, adminUser, adminPassword, schema);
 		dialect.createUser(user, password, adminUser, adminPassword);
-        dialect.createSchema(schema, user, password, adminUser, adminPassword);
-
-
+		dialect.dropAll(user, password, adminUser, adminPassword, schema);
+		
         FilenameFilter sqlFileFilter = new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
@@ -87,7 +97,8 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 			getLog().warn(e);
 		}
 
-        dialect.grantAllToAnotherSchema(schema, user, password, adminUser, adminPassword);
+		// DBユーザにスキーマオブジェクトの権限を付与する
+        dialect.grantAllToUser(schema, user, password, adminUser, adminPassword);
 	}
 
     private void executeSql(String sql) throws SQLException {


### PR DESCRIPTION
- dropAll()の役割を下記のように変更。
    - 指定スキーマがなければ作成する。
    - 指定スキーマがあれば、空のスキーマに戻す。
- createUser()の役割を下記のように変更。
    - 無条件で指定ユーザを削除。
    - 指定ユーザを作成します。
- updateDefaultSchema()を新設しました。これはddlファイル実行前に呼び出されます。
    - Postgresql、SQLServerはDDLを実行するまえに、デフォルトのスキーマやスキーマ探索パスを設定しておく必要があるため。
    - 他のDBでは空実装。
- その他修正
    - mysqlのdropAllの処理をDROP DATABASE文に変更。
    - grantAllToAnotherSchema()のメソッド名をgrantAllToUser()に変更。