### PR TITLE
DBユーザに付与するスキーマ内オブジェクトの権限をテーブル、ビュー、シーケンスのみに変更。

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -289,4 +289,37 @@ public abstract class Dialect {
             StatementUtil.close(stmt);
         }
     }
+    
+    protected void grantSchemaObjToUser(Connection conn, String grantListSql, String schema, String user, OBJECT_TYPE objType) throws SQLException {
+    	Statement stmt = null;
+    	ResultSet rs = null;
+    	
+    	try {
+    	  stmt = conn.createStatement();
+    	  rs = stmt.executeQuery(grantListSql);
+    	  String grantSql = "";
+    	  
+    	  while (rs.next()) {
+      	      switch (objType) {
+  		        case TABLE: // テーブル
+  		        	grantSql = "GRANT ALL ON "  + schema + "." + rs.getString(1) + " TO " + user;
+    		      break;
+  		        case VIEW: // ビュー
+  		        	grantSql = "GRANT ALL ON "  + schema + "." + rs.getString(1) + " TO " + user;
+  			      break;
+  		        case SEQUENCE: // シーケンス
+  		        	grantSql = "GRANT ALL ON "  + schema + "." + rs.getString(1) + " TO " + user;
+          		  break;
+         		default:
+          		  break;
+  		      }
+      	    
+      	    stmt = conn.createStatement();
+      	    System.err.println(grantSql);
+      	    stmt.execute(grantSql);
+    	  }
+        } finally {
+            StatementUtil.close(stmt);
+        }
+    }
 }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -200,8 +200,15 @@ public class MysqlDialect extends Dialect {
 		Connection conn = null;
 		try {
 			conn = DriverManager.getConnection(url, admin, adminPassword);
-			stmt = conn.createStatement();
-		    stmt.execute("GRANT ALL ON " + schema + ".* TO '" + user + "'");
+			
+			String nmzschema = normalizeSchemaName(schema);
+			
+			String grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA='" + nmzschema + "'";
+			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.VIEW);
+			
+			grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='" + nmzschema + "'";
+			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.TABLE);
+			
 		} catch (SQLException e) {
 			throw new MojoExecutionException("スキーマ権限付与実行エラー", e);
 		} finally {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -209,11 +209,11 @@ public class OracleDialect extends Dialect {
         
         try{
         	conn = getJDBCConnection(driver, admin, adminPassword);
-			PreparedStatement stmt = conn.prepareStatement("SELECT TABLE_NAME FROM DBA_TABLES WHERE OWNER = ?");
+			PreparedStatement stmt = conn.prepareStatement("SELECT OBJECT_NAME FROM DBA_OBJECTS WHERE OBJECT_TYPE IN ('TABLE', 'VIEW', 'SEQUENCE') AND OWNER = ?");
 			stmt.setString(1, StringUtils.upperCase(schema));
 			ResultSet rs = stmt.executeQuery();
 			while (rs.next()) {
-				String tableName = rs.getString("TABLE_NAME");
+				String tableName = rs.getString("OBJECT_NAME");
 				// PreparedStatementで埋め込めるのはキーワードだけであり、スキーマ名やテーブル名には使用できないため。
 				String sql = "GRANT ALL ON " + schema + "." + tableName + " TO " + user;
 				conn.createStatement().execute(sql);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -125,6 +125,7 @@ public class PostgresqlDialect extends Dialect {
                 stmt.execute("ALTER USER " + user + " Set search_path TO " + schema);
             	return;
             }else{
+            	// 指定スキーマが存在する場合はスキーマ操作権限を念のため与えておく
                 stmt.execute("ALTER SCHEMA " + schema + " OWNER TO " + user);
                 stmt.execute("ALTER USER " + user + " Set search_path TO " + schema);
             }
@@ -224,8 +225,9 @@ public class PostgresqlDialect extends Dialect {
         try{
         	conn = getJDBCConnection(driver, admin, adminPassword);
         	stmt = conn.createStatement();
-        	stmt.execute("GRANT ALL ON ALL TABLES IN SCHEMA " + schema + " TO " + user);
-        	stmt.execute("GRANT ALL ON ALL SEQUENCES IN SCHEMA " + schema + " TO " + user);
+        	stmt.execute("GRANT ALL ON SCHEMA " + schema + " TO " + user); // スキーマ自体への権限
+        	stmt.execute("GRANT ALL ON ALL TABLES IN SCHEMA " + schema + " TO " + user); // テーブルとビュー
+        	stmt.execute("GRANT ALL ON ALL SEQUENCES IN SCHEMA " + schema + " TO " + user); // シーケンス
         
         } catch (SQLException e) {
             throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
@@ -74,6 +74,7 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 		dialect.createUser(user, password, adminUser, adminPassword);
 		
 		// 指定スキーマ内のテーブル、ビュー、シーケンスを全て削除します。
+		// 指定スキーマが存在しない場合は作成します。
 		dialect.dropAll(user, password, adminUser, adminPassword, schema);
 		
         FilenameFilter sqlFileFilter = new FilenameFilter() {


### PR DESCRIPTION
- 変更点
    - Before
       各DialectでDBユーザに対して付与するスキーマ内オブジェクトの権限がテーブルだけになっているものが大きかった。統一されていなかった。
    - After
        各DialectでDBユーザに対するスキーマ内オブジェクトの権限付与対象オブジェクトをテーブルとビュー、シーケンスのみにした。