### PR TITLE
Dialect内のJDBC登録処理を生成時のみに変更。getJDBCConnectionは不要なので削除。

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
@@ -80,7 +80,6 @@ public class Db2Dialect extends Dialect {
     @Override
     public void dropAll(String user, String password, String adminUser,
             String adminPassword, String schema) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         try {
@@ -146,7 +145,6 @@ public class Db2Dialect extends Dialect {
     @Override
     public void createUser(String user, String password, String adminUser,
             String adminPassword) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         try {
@@ -175,7 +173,7 @@ public class Db2Dialect extends Dialect {
         
         try{
         	// テーブルとビュー
-        	conn = getJDBCConnection(driver, admin, adminPassword);
+        	conn = DriverManager.getConnection(url, admin, adminPassword);
         	
 			String nmzschema = normalizeSchemaName(schema);
 			
@@ -236,7 +234,7 @@ public class Db2Dialect extends Dialect {
         Connection conn = null;
     	
         try{
-			conn = getJDBCConnection(driver, admin, adminPassword);
+			conn = DriverManager.getConnection(url, admin, adminPassword);
 			createUserStmt = conn.createStatement();
 			createUserStmt.execute("CREATE SCHEMA " + schema + " AUTHORIZATION " + user);
 		

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -97,6 +97,7 @@ public abstract class Dialect {
     }
     
 	public void setDriver(String driver) {
+		DriverManagerUtil.registerDriver(driver);
 		this.driver = driver;
 	}
 	
@@ -250,12 +251,7 @@ public abstract class Dialect {
         }
         return null;
     }
-    
-    protected Connection getJDBCConnection(String driver, String user, String password) throws SQLException{
-    	DriverManagerUtil.registerDriver(driver);
-    	return DriverManager.getConnection(url, user, password);
-    }
-    
+
     protected void dropObjectsInSchema(Connection conn, String dropListSql, String schema, OBJECT_TYPE objType) throws SQLException {
     	Statement stmt = null;
     	ResultSet rs = null;

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -32,7 +32,6 @@ public class H2Dialect extends Dialect {
     @Override
     public void exportSchema(String user, String password, String schema,
             File dumpFile) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         try {
             conn = DriverManager.getConnection(url, user, password);
@@ -49,7 +48,6 @@ public class H2Dialect extends Dialect {
     @Override
     public void dropAll(String user, String password, String adminUser,
             String adminPassword, String schema) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         PreparedStatement pstmt = null;
         
@@ -106,7 +104,6 @@ public class H2Dialect extends Dialect {
     @Override
     public void importSchema(String user, String password, String schema,
             File dumpFile) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         try {
             conn = DriverManager.getConnection(url, user, password);
@@ -144,7 +141,7 @@ public class H2Dialect extends Dialect {
         PreparedStatement pstmt = null;
     	
     	try{
-    		conn = getJDBCConnection(driver, admin, adminPassword);
+    		conn = DriverManager.getConnection(url, admin, adminPassword);
 
 			String nmzschema = normalizeSchemaName(schema);
 			
@@ -167,7 +164,7 @@ public class H2Dialect extends Dialect {
         Connection conn = null;
         
 		try {
-			conn = getJDBCConnection(driver, admin, adminPassword);
+			conn = DriverManager.getConnection(url, admin, adminPassword);
 			stmt = conn.createStatement();
 			stmt.execute("CREATE SCHEMA IF NOT EXISTS " + schema);
 		} catch (SQLException e) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -187,7 +187,6 @@ public class MysqlDialect extends Dialect {
 
 	@Override
 	public void createUser(String user, String password, String adminUser, String adminPassword) throws MojoExecutionException{
-		DriverManagerUtil.registerDriver(driver);
 		Connection conn = null;
 		Statement stmt = null;
 		try {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -172,7 +172,6 @@ public class OracleDialect extends Dialect {
 	 */
 	@Override
 	public void createUser(String user, String password, String adminUser, String adminPassword) throws MojoExecutionException {
-		DriverManagerUtil.registerDriver(driver);
 		Connection conn = null;
 		Statement stmt = null;
 		try {
@@ -208,7 +207,7 @@ public class OracleDialect extends Dialect {
         PreparedStatement pstmt = null;
         
         try{
-        	conn = getJDBCConnection(driver, admin, adminPassword);
+        	conn = DriverManager.getConnection(url, admin, adminPassword);
 			PreparedStatement stmt = conn.prepareStatement("SELECT OBJECT_NAME FROM DBA_OBJECTS WHERE OBJECT_TYPE IN ('TABLE', 'VIEW', 'SEQUENCE') AND OWNER = ?");
 			stmt.setString(1, StringUtils.upperCase(schema));
 			ResultSet rs = stmt.executeQuery();
@@ -233,7 +232,7 @@ public class OracleDialect extends Dialect {
 		Connection conn = null;
 		
 		try{
-			conn = getJDBCConnection(driver, admin, adminPassword);
+			conn = DriverManager.getConnection(url, admin, adminPassword);
 			createUserStmt= conn.createStatement();
 			createUserStmt.execute("CREATE USER "+ schema + " IDENTIFIED BY "+ schema + " DEFAULT TABLESPACE users");
 			String grantSql = "GRANT CREATE SESSION, UNLIMITED TABLESPACE, CREATE CLUSTER, CREATE INDEXTYPE, CREATE OPERATOR, " +
@@ -268,7 +267,6 @@ public class OracleDialect extends Dialect {
 	@Override
 	public void dropAll(String user, String password, String adminUser,
 			String adminPassword, String schema) throws MojoExecutionException {
-		DriverManagerUtil.registerDriver(driver);
 		Connection conn = null;
 		try {
 			conn = DriverManager.getConnection(url, adminUser, adminPassword);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -112,7 +112,6 @@ public class PostgresqlDialect extends Dialect {
     @Override
     public void dropAll(String user, String password, String adminUser,
             String adminPassword, String schema) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         try {
@@ -194,7 +193,6 @@ public class PostgresqlDialect extends Dialect {
     @Override
     public void createUser(String user, String password, String adminUser,
             String adminPassword) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         String database = getDatabase();
@@ -223,7 +221,7 @@ public class PostgresqlDialect extends Dialect {
         Statement stmt = null;
         
         try{
-        	conn = getJDBCConnection(driver, admin, adminPassword);
+        	conn = DriverManager.getConnection(url, admin, adminPassword);
         	stmt = conn.createStatement();
         	stmt.execute("GRANT ALL ON SCHEMA " + schema + " TO " + user); // スキーマ自体への権限
         	stmt.execute("GRANT ALL ON ALL TABLES IN SCHEMA " + schema + " TO " + user); // テーブルとビュー

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -92,7 +92,6 @@ public class SqlserverDialect extends Dialect {
     @Override
     public void dropAll(String user, String password, String adminUser,
             String adminPassword, String schema) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         PreparedStatement dropStmt;
@@ -148,7 +147,6 @@ public class SqlserverDialect extends Dialect {
     @Override
     public void createUser(String user, String password, String adminUser,
             String adminPassword) throws MojoExecutionException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         Statement stmt = null;
         try {
@@ -189,7 +187,6 @@ public class SqlserverDialect extends Dialect {
     }
 
     private boolean existsUser(String adminUser, String adminPassword, String user) throws SQLException {
-        DriverManagerUtil.registerDriver(driver);
         Connection conn = null;
         PreparedStatement stmt = null;
         boolean existLogin = false;
@@ -247,7 +244,7 @@ public class SqlserverDialect extends Dialect {
     	Statement stmt = null;
     	
     	try{    	
-	    	conn = getJDBCConnection(driver, admin, adminPassword);
+	    	conn = DriverManager.getConnection(url, admin, adminPassword);
 	    	stmt = conn.createStatement();
 	        ResultSet rs = stmt.executeQuery("SELECT NAME FROM SYS.OBJECTS WHERE SCHEMA_ID = SCHEMA_ID('" + schema + "') AND TYPE IN ('U','V')");
 	        StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- 変更点
    - Dialect内で何度も行われていたJDBCドライバクラスの登録処理をDialectFactory.getDialect()によるDialect生成時のDialect.setDriver()の中で行うようにしてみた。
    - getJDBCConnection()の存在価値がなくなったので削除。元のDriverManager.getConnectionに戻した。
- コンストラクタを見直して不要な生成処理を隠ぺいしたかったがインターフェースが変わる可能性があるので一旦見送り。