### PR TITLE
全ゴールの処理前に、ユーザ名とスキーマ名をDialect毎のnormalize処理した値で上書きする。

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
@@ -253,6 +253,11 @@ public class Db2Dialect extends Dialect {
     }
     
     @Override
+    public String normalizeUserName(String userName) {
+    	return StringUtils.upperCase(userName);
+    }
+    
+    @Override
     public String normalizeSchemaName(String schemaName) {
         return StringUtils.upperCase(schemaName);
     }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import javax.persistence.GenerationType;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.seasar.extension.jdbc.gen.meta.DbTableMeta;
 import org.seasar.framework.util.DriverManagerUtil;
@@ -115,6 +116,10 @@ public abstract class Dialect {
     }
 
 	public abstract TypeMapper getTypeMapper();
+	
+    public String normalizeUserName(String userName) {
+        return userName;
+    }
 
 	public String normalizeSchemaName(String schemaName) {
 		return schemaName;
@@ -172,7 +177,7 @@ public abstract class Dialect {
         ResultSet rs = null;
         try {
             rs = metaData.getColumns(null,
-                                                normalizeSchemaName(schema),
+            		                            schema,
                                                 normalizeTableName(tableName),
                                                 normalizeColumnName(colName));
             if (!rs.next()) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -96,6 +96,11 @@ public class H2Dialect extends Dialect {
        	  StatementUtil.close(pstmt);
         }
     }   
+    
+    @Override
+    public String normalizeUserName(String userName) {
+    	return StringUtils.upperCase(userName);
+    }
         
 	public String normalizeSchemaName(String schemaName) {
 		return StringUtils.upperCase(schemaName);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -132,7 +132,7 @@ public class MysqlDialect extends Dialect {
 			stmt = conn.createStatement();
 
 			// スキーマ内のテーブル、ビュー削除
-			String nmzschema = normalizeSchemaName(schema);
+			String nmzschema = schema;
 			String dropListSql = "SELECT TABLE_NAME, CONSTRAINT_NAME FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA='" + nmzschema + "'";
 			dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.FK);
 			
@@ -211,7 +211,7 @@ public class MysqlDialect extends Dialect {
 		try {
 			conn = DriverManager.getConnection(url, admin, adminPassword);
 			
-			String nmzschema = normalizeSchemaName(schema);
+			String nmzschema = schema;
 			
 			String grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA='" + nmzschema + "'";
 			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.VIEW);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -209,7 +209,7 @@ public class OracleDialect extends Dialect {
         try{
         	conn = DriverManager.getConnection(url, admin, adminPassword);
 			PreparedStatement stmt = conn.prepareStatement("SELECT OBJECT_NAME FROM DBA_OBJECTS WHERE OBJECT_TYPE IN ('TABLE', 'VIEW', 'SEQUENCE') AND OWNER = ?");
-			stmt.setString(1, StringUtils.upperCase(schema));
+			stmt.setString(1, schema);
 			ResultSet rs = stmt.executeQuery();
 			while (rs.next()) {
 				String tableName = rs.getString("OBJECT_NAME");
@@ -255,7 +255,7 @@ public class OracleDialect extends Dialect {
 		try {
 			stmt = conn.prepareStatement(
 					"SELECT count(*) AS num FROM dba_users WHERE username=?");
-			stmt.setString(1, StringUtils.upperCase(user));
+			stmt.setString(1, user);
 			ResultSet rs = stmt.executeQuery();
 			rs.next();
 			return (rs.getInt("num") > 0);
@@ -324,6 +324,11 @@ public class OracleDialect extends Dialect {
 	public TypeMapper getTypeMapper() {
 		return new TypeMapper(typeToNameMap);
 	}
+	
+    @Override
+    public String normalizeUserName(String userName) {
+    	return StringUtils.upperCase(userName);
+    }
 
 	@Override
 	public String normalizeSchemaName(String schemaName) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -239,6 +239,11 @@ public class PostgresqlDialect extends Dialect {
     public TypeMapper getTypeMapper() {
         return null;
     }
+    
+    @Override
+    public String normalizeUserName(String userName) {
+        return StringUtils.lowerCase(userName);
+    }
 
     @Override
     public String normalizeSchemaName(String schemaName) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -110,7 +110,7 @@ public class SqlserverDialect extends Dialect {
             
             // 依存関係を考慮し削除するテーブルをソートする
             EntityDependencyParser parser = new EntityDependencyParser();
-            parser.parse(conn, url, normalizeSchemaName(schema));
+            parser.parse(conn, url, schema);
             final List<String> tableList = parser.getTableList();
             Collections.reverse(tableList);
             for (String table : tableList) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
@@ -18,6 +18,7 @@ package jp.co.tis.gsp.tools.dba.mojo;
 
 import java.util.Map;
 
+import jp.co.tis.gsp.tools.dba.dialect.Dialect;
 import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -114,13 +115,20 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
     public final void execute() throws MojoExecutionException, MojoFailureException {
         registerOptionalDialect();
         setupEnvironments();
+        
+        Dialect dialect = DialectFactory.getDialect(url, driver);
+        user = dialect.normalizeUserName(user);
+        
         if(schema == null){
             if (url.split(":")[1].equals("h2")) {
                 schema = "PUBLIC";
             } else {
                 schema = user;
             }
+        }else{
+        	schema = dialect.normalizeSchemaName(schema);
         }
+        
         executeMojoSpec();
     }
 

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/GenerateEntity.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/GenerateEntity.java
@@ -183,7 +183,7 @@ public class GenerateEntity extends AbstractDbaMojo {
         Dialect dialect = DialectFactory.getDialect(url, driver);
         DialectUtil.setDialect(dialect);
         final GenerateEntityCommand command = new GenerateEntityCommand();
-        command.setSchemaName(dialect.normalizeSchemaName(schema));
+        command.setSchemaName(schema);
         command.setOverwrite(true);
         command.setApplyDbCommentToJava(true);
         command.setEntityPackageName(entityPackageName);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/LoadDataMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/LoadDataMojo.java
@@ -92,7 +92,7 @@ public class LoadDataMojo extends AbstractDbaMojo {
 		// 依存関係を考慮し読み込むファイル順をソートする
 		EntityDependencyParser parser = new EntityDependencyParser();
 		Dialect dialect = DialectFactory.getDialect(url, driver);
-		parser.parse(conn, url, dialect.normalizeSchemaName(schema));
+		parser.parse(conn, url, schema);
 		final List<String> tableList = parser.getTableList();
 		Collections.sort(files, new Comparator<File>() {
 			@Override


### PR DESCRIPTION
#### 本プルリクで対応した具体的な修正内容
- ゴール処理の前で、ユーザ名とスキーマ名をnormalize処理した値で上書きする。
- 以降の処理で、スキーマ名をnormalize処理している箇所を削除（＝変数schemaを参照するように）
- OracleDialectにおいて、normalizeメソッドを呼び出さずに直接StringUti.uppercaseメソッドを使って大文字化していたコードを削除。