### PR TITLE
MySQL:ダンプ出力時のパラメータを追加。default-character-set=utf8, hex-blob

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -88,7 +88,9 @@ public class MysqlDialect extends Dialect {
 					"mysqldump",
 					schema,
 					"-u", user,
-					"--password="+password);
+					"--password="+password,
+					"--default-character-set=utf8",
+					"--hex-blob");
 			Process process = pb.start();
 			in = new BufferedInputStream(process.getInputStream());
 


### PR DESCRIPTION
バイナリデータを正しく格納する対応。