### PR TITLE
MySQLのスキーマ指定不可対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pom.xmlに以下の設定を追加することでプラグインが使用でき�
 | adminPassword  | ×     | adminUserに設定したユーザのパスワード。                        |
 | user           | ○     | データベースのユーザ名。 Oracleの場合はsysは指定出来ません。PostgreSQLの場合は常に小文字に変換して処理されます。|
 | password       | ×     | userに設定したユーザのパスワード。                             |
-| schema         | ×     | データベースのスキーマ名。<br />H2Databaseの場合は指定不可、常にPUBLICスキーマとして解釈します。 MySQLの場合は指定不可、jdbcのURLよりスキーマ名を自動設定します。 それ以外のDBでスキーマを指定しない場合はユーザ名と同じスキーマ名を使用すると解釈されます。 PostgreSQLの場合は常に小文字に、H2、DB2、Oracleの場合は常に大文字に変換して処理されます。|
+| schema         | ×     | データベースのスキーマ名。<br />H2Databaseの場合は指定不可、常にPUBLICスキーマとして解釈します。<br /> MySQLの場合は指定不可、jdbcのURLのデータベース名をスキーマ名として設定します。<br /> 例）jdbc:mysql://localhost:3306/gspdb → gspdbをスキーマ名として内部で使用します。<br /> それ以外のDBでスキーマを指定しない場合はユーザ名と同じスキーマ名を使用すると解釈されます。 PostgreSQLの場合は常に小文字に、H2、DB2、Oracleの場合は常に大文字に変換して処理されます。|
 | dmpFile        | ×     | ダンプファイル名。指定しなかった場合、[スキーマ名].dmpとなる。 |
 |optionalDialects | ×    | 使用するダイアレクトクラスのFQCN。|
 |onError | ×    | generate-ddlとload-dataで使用。SQL実行中にエラーが発生した場合の挙動を指定。<br />`abort`(デフォルト)・・・処理を中断する。<br />`continue` ・・・処理を継続する。|

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pom.xmlに以下の設定を追加することでプラグインが使用でき�
 | adminPassword  | ×     | adminUserに設定したユーザのパスワード。                        |
 | user           | ○     | データベースのユーザ名。 Oracleの場合はsysは指定出来ません。PostgreSQLの場合は常に小文字に変換して処理されます。|
 | password       | ×     | userに設定したユーザのパスワード。                             |
-| schema         | ×     | データベースのスキーマ名。<br />H2Databaseの場合は指定不可、常にPUBLICスキーマとして解釈します。  それ以外のDBでスキーマを指定しない場合はユーザ名と同じスキーマ名を使用すると解釈されます。 PostgreSQLの場合は常に小文字に、H2、DB2、Oracleの場合は常に大文字に変換して処理されます。|
+| schema         | ×     | データベースのスキーマ名。<br />H2Databaseの場合は指定不可、常にPUBLICスキーマとして解釈します。 MySQLの場合は指定不可、jdbcのURLよりスキーマ名を自動設定します。 それ以外のDBでスキーマを指定しない場合はユーザ名と同じスキーマ名を使用すると解釈されます。 PostgreSQLの場合は常に小文字に、H2、DB2、Oracleの場合は常に大文字に変換して処理されます。|
 | dmpFile        | ×     | ダンプファイル名。指定しなかった場合、[スキーマ名].dmpとなる。 |
 |optionalDialects | ×    | 使用するダイアレクトクラスのFQCN。|
 |onError | ×    | generate-ddlとload-dataで使用。SQL実行中にエラーが発生した場合の挙動を指定。<br />`abort`(デフォルト)・・・処理を中断する。<br />`continue` ・・・処理を継続する。|

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -165,13 +165,13 @@ public class MysqlDialect extends Dialect {
     	  while (rs.next()) {
       	      switch (objType) {
 		        case FK:
-  		        	dropSql = "ALTER TABLE " + schema + "." + rs.getString(1) + " DROP FOREIGN KEY " + rs.getString(2);
+  		        	dropSql = "ALTER TABLE " + rs.getString(1) + " DROP FOREIGN KEY " + rs.getString(2);
           		  break;
   		        case TABLE:
-  		        	dropSql = "DROP TABLE "  + schema + "." + rs.getString(1);
+  		        	dropSql = "DROP TABLE "  + rs.getString(1);
     		      break;
   		        case VIEW:
-  		        	dropSql = "DROP VIEW "  + schema + "." + rs.getString(1);
+  		        	dropSql = "DROP VIEW "  + rs.getString(1);
   			      break;
          		default: // シーケンスは未サポート
   			      break;

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
@@ -16,15 +16,18 @@
 
 package jp.co.tis.gsp.tools.dba.mojo;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 import java.util.Map;
-
-import jp.co.tis.gsp.tools.dba.dialect.Dialect;
-import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
+
+import jp.co.tis.gsp.tools.dba.dialect.Dialect;
+import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
 
 public abstract class AbstractDbaMojo extends AbstractMojo {
     /**
@@ -130,10 +133,22 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
         if(schema == null){
             if (url.split(":")[1].equals("h2")) {
                 schema = "PUBLIC";
-            } else {
+            } else if(url.split(":")[1].equals("mysql")) {
+            	try {
+            		//データベース名をスキーマ名としてセット
+					Connection conn = DriverManager.getConnection(url, adminUser, adminPassword);
+					schema = dialect.normalizeSchemaName(conn.getCatalog());
+				} catch (SQLException e) {
+					throw new MojoExecutionException("MySQL:データベース名の取得に失敗しました。", e);
+				}
+            }else {
                 schema = user;
             }
         }else{
+        	if(url.split(":")[1].equals("mysql")) {
+        		throw new MojoExecutionException("MySQLではスキーマを指定することは出来ません。");
+        	}
+        	
         	schema = dialect.normalizeSchemaName(schema);
         }
         


### PR DESCRIPTION
以下の対応を行いました。
- MySQLの時にパラメータ：schemaが指定された時はエラーにするようにしました。
- MySQLの時はschemaがセットされないため、jdbcコネクションを取得し、そこからカタログ名（データベース名）を取得してそれをschema名にセットするように修正しました。