### PR TITLE
dropAll()からシーケンス削除処理を削除。

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
@@ -30,7 +30,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
 import org.seasar.extension.jdbc.gen.dialect.GenDialectRegistry;
 import org.seasar.extension.jdbc.util.ConnectionUtil;
-import org.seasar.framework.util.DriverManagerUtil;
 import org.seasar.framework.util.StatementUtil;
 
 import jp.co.tis.gsp.tools.db.TypeMapper;
@@ -106,9 +105,6 @@ public class Db2Dialect extends Dialect {
 			dropListSql = "SELECT TABNAME FROM SYSCAT.TABLES WHERE OWNERTYPE='U' AND TYPE IN('T') AND TABSCHEMA='" + nmzschema + "'";
 	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.TABLE);
 			
-			dropListSql = "SELECT SEQNAME FROM SYSCAT.SEQUENCES WHERE OWNERTYPE='U' AND ORIGIN='U' AND SEQSCHEMA='" + nmzschema + "'";
-	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.SEQUENCE);
-            
         } catch (SQLException e) {
             throw new MojoExecutionException("データ削除中にエラー", e);
         } finally {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -67,9 +67,6 @@ public class H2Dialect extends Dialect {
 			dropListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='" + nmzschema + "'"; 
 	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.TABLE);
 			
-			dropListSql = "SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES WHERE IS_GENERATED=FALSE AND SEQUENCE_SCHEMA='" + nmzschema + "'";
-	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.SEQUENCE);
-            
         } catch (SQLException e) {
             throw new MojoExecutionException("DROP ALL実行中にエラー", e);
         } finally {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -141,9 +141,6 @@ public class PostgresqlDialect extends Dialect {
 			dropListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE' AND TABLE_SCHEMA='" + nmzschema + "'";
 	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.TABLE);
 			
-			dropListSql = "SELECT RELNAME FROM PG_STATIO_ALL_SEQUENCES WHERE SCHEMANAME='" + nmzschema + "'";
-	        dropObjectsInSchema(conn, dropListSql, nmzschema, OBJECT_TYPE.SEQUENCE);            
-            
         } catch (SQLException e) {
             throw new MojoExecutionException("データ削除中にエラー", e);
         } finally {


### PR DESCRIPTION
Oracleのシーケンス削除処理は有効のまま。