### PR TITLE
postgresqlのPK定義方法変更

### DIFF
--- a/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
+++ b/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
@@ -1,13 +1,11 @@
-<#-- postgresqlではalter table句で復号主キー制約を設定できないため、主キーの定義はcreateTableで行う。 -->
-<#if !index.isPrimaryKey()>
-<#if index.type=1>
-ALTER TABLE <#if entity.schema??>${entity.schema}</#if>${entity.name} ADD CONSTRAINT ${index.name!} UNIQUE
+<#if index.isPrimaryKey()>
+ALTER TABLE ${entity.name}
+ADD CONSTRAINT ${index.name!} PRIMARY KEY
 <#else>
-CREATE <#if index.type=2>UNIQUE </#if>INDEX ${index.name} ON <#if entity.schema??>${entity.schema}</#if>${entity.name}
+CREATE <#if index.type=1 || index.type=2>UNIQUE </#if>INDEX ${index.name} ON ${entity.name}
 </#if>
 (
 <#foreach column in index.columnList>
   ${column.name}<#if column_has_next>,</#if>
 </#foreach>
 );
-</#if>

--- a/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createTable.ftl
+++ b/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createTable.ftl
@@ -1,25 +1,20 @@
 <#-- postgresql create table template -->
-<#-- Postgresqlは複数主キーをalter tableで指定できないため、こちらで設定する。 -->
-<#-- また、SERIAL型・BIGSERIAL型は自動生成型であるため、これらの型の場合はシーケンスを生成しない。 -->
-CREATE TABLE <#if entity.schema??>${entity.schema}</#if>${entity.name} (
+<#-- SERIAL型・BIGSERIAL型は自動生成型であるため、これらの型の場合はシーケンスを生成しない。 -->
+CREATE TABLE ${entity.name} (
 <#foreach column in entity.columnList>
-  ${column.name} ${column.dataType}<#if column.length != 0>(${column.length}<#if column.scale!=0>,${column.scale}</#if>)</#if><#if column.isArray()> ARRAY</#if><#if !column.isNullable()> NOT NULL</#if><#if column.defaultValue?has_content> DEFAULT ${column.defaultValue}</#if><#if column_has_next>,<#else><#if entity.havePrimaryKey()>,</#if></#if>
+  ${column.name} ${column.dataType}<#if column.length != 0>(${column.length}<#if column.scale!=0>,${column.scale}</#if>)</#if><#if column.isArray()> ARRAY</#if><#if !column.isNullable()> NOT NULL</#if><#if column.defaultValue?has_content> DEFAULT ${column.defaultValue}</#if><#if column_has_next>,<#else></#if>
 </#foreach>
-<#if entity.havePrimaryKey()>
-<#assign isFirst = "true" />
-  PRIMARY KEY (<#foreach column in entity.columnList><#if column.isPrimaryKey()><#if isFirst!="true">, </#if>${column.name}<#assign isFirst = "false" /></#if></#foreach>)
-</#if>
 );
 <#if entity.label?has_content>
-COMMENT ON table <#if entity.schema??>${entity.schema}</#if>${entity.name} is '${entity.label}';
+COMMENT ON table ${entity.name} is '${entity.label}';
 </#if>
 <#foreach column in entity.columnList>
 <#if column.label?has_content>
-COMMENT ON column <#if entity.schema??>${entity.schema}</#if>${entity.name}.${column.name} is '${column.label}';
+COMMENT ON column ${entity.name}.${column.name} is '${column.label}';
 </#if>
 </#foreach>
 <#foreach column in entity.columnList>
 <#if column.isAutoIncrement() && column.dataType!='SERIAL' && column.dataType!='BIGSERIAL'>
-CREATE SEQUENCE <#if entity.schema??>${entity.schema}</#if>${column.generatorKeyName} increment by 1 start with 1;
+CREATE SEQUENCE ${column.generatorKeyName} increment by 1 start with 1;
 </#if>
 </#foreach>


### PR DESCRIPTION
postgresql向けに生成されるDDLのPKがTABLEの列順で定義されていたが、
oracle向けに生成されるDDLの出力と同様にINDEXの列順で定義するように修正。

Postgresql9.1以降のドキュメント上はこの記法が可能になっている。
dao.findAllBySqlFileから設定するパラメータの順序に影響するためPKの出力順は合わせておいてほしい。