### PR TITLE
Oracleのインポートエクスポートに関わる権限周りの処理を見直し

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Db2Dialect.java
@@ -160,32 +160,6 @@ public class Db2Dialect extends Dialect {
             ConnectionUtil.close(conn);
         }
     }
-
-    @Override
-    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-    	
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        
-        try{
-        	// テーブルとビュー
-        	conn = DriverManager.getConnection(url, admin, adminPassword);
-        	
-			String nmzschema = normalizeSchemaName(schema);
-			
-			String grantListSql = "SELECT TABNAME FROM SYSCAT.TABLES WHERE OWNERTYPE='U' AND TYPE IN('V') AND TABSCHEMA='" + nmzschema + "'";
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.VIEW);
-			
-			grantListSql = "SELECT TABNAME FROM SYSCAT.TABLES WHERE OWNERTYPE='U' AND TYPE IN('T') AND TABSCHEMA='" + nmzschema + "'";
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.TABLE);
-			
-        } catch (SQLException e) {
-            throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);
-        } finally {
-        	StatementUtil.close(pstmt);
-            ConnectionUtil.close(conn);
-        }
-    }
 	
 	@Override
     protected void grantSchemaObjToUser(Connection conn, String grantListSql, String schema, String user, OBJECT_TYPE objType) throws SQLException {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -19,7 +19,6 @@ package jp.co.tis.gsp.tools.dba.dialect;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -30,7 +29,6 @@ import java.util.List;
 
 import javax.persistence.GenerationType;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.seasar.extension.jdbc.gen.meta.DbTableMeta;
 import org.seasar.framework.util.DriverManagerUtil;
@@ -40,7 +38,6 @@ import org.seasar.framework.util.StringUtil;
 
 import jp.co.tis.gsp.tools.db.AlternativeGenerator;
 import jp.co.tis.gsp.tools.db.TypeMapper;
-import jp.co.tis.gsp.tools.dba.dialect.Dialect.OBJECT_TYPE;
 
 public abstract class Dialect {
 	
@@ -97,19 +94,6 @@ public abstract class Dialect {
 		DriverManagerUtil.registerDriver(driver);
 		this.driver = driver;
 	}
-	
-    /**
-     * ユーザ名とスキーマ名が不一致の場合、別名のスキーマに対して
-     * アプリユーザが操作を行えるよう権限を付与する。
-     * デフォルトでは何もしない。
-     * @param conn DBコネクション
-     * @param schema スキーマ名
-     * @param user ユーザ名
-     * @throws MojoExecutionException エラー
-     */
-    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-        // nop
-    }
 
 	public abstract TypeMapper getTypeMapper();
 	

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -118,31 +118,6 @@ public class H2Dialect extends Dialect {
     }
 
     @Override
-    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-    	
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-    	
-    	try{
-    		conn = DriverManager.getConnection(url, admin, adminPassword);
-
-			String nmzschema = normalizeSchemaName(schema);
-			
-			String grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA='" + nmzschema + "'"; 
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.VIEW);
-			
-			grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='" + nmzschema + "'"; 
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.TABLE);
-        
-        } catch (SQLException e) {
-            throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);
-        } finally {
-        	StatementUtil.close(pstmt);
-            ConnectionUtil.close(conn);
-        }
-    }
-
-    @Override
     public TypeMapper getTypeMapper() {
         return new TypeMapper();
     }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/H2Dialect.java
@@ -34,7 +34,7 @@ public class H2Dialect extends Dialect {
         try {
             conn = DriverManager.getConnection(url, user, password);
             Statement stmt = conn.createStatement();
-            stmt.execute("SCRIPT TO '" + dumpFile.getAbsolutePath()+ "'");
+            stmt.execute("SCRIPT DROP TO '" + dumpFile.getAbsolutePath()+ "'");
             StatementUtil.close(stmt);
         } catch (SQLException e) {
             throw new MojoExecutionException("Schema export実行中にエラー", e);

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -27,26 +27,18 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.seasar.extension.jdbc.gen.dialect.GenDialectRegistry;
 import org.seasar.extension.jdbc.gen.meta.DbTableMeta;
 import org.seasar.extension.jdbc.util.ConnectionUtil;
-import org.seasar.framework.exception.IORuntimeException;
-import org.seasar.framework.util.DriverManagerUtil;
 import org.seasar.framework.util.FileOutputStreamUtil;
 import org.seasar.framework.util.ResultSetUtil;
 import org.seasar.framework.util.StatementUtil;
-import org.seasar.framework.util.tiger.CollectionsUtil;
 import org.seasar.framework.util.tiger.Maps;
 
-import jp.co.tis.gsp.tools.db.AbstractDbObjectParser;
-import jp.co.tis.gsp.tools.db.AlternativeGenerator;
 import jp.co.tis.gsp.tools.db.TypeMapper;
 import jp.co.tis.gsp.tools.dba.util.ProcessUtil;
 
@@ -209,30 +201,6 @@ public class MysqlDialect extends Dialect {
 			ConnectionUtil.close(conn);
 		}
 	}
-	
-	@Override
-	public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-		Statement stmt = null;
-		Connection conn = null;
-		try {
-			conn = DriverManager.getConnection(url, admin, adminPassword);
-			
-			String nmzschema = schema;
-			
-			String grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA='" + nmzschema + "'";
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.VIEW);
-			
-			grantListSql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='" + nmzschema + "'";
-			grantSchemaObjToUser(conn, grantListSql, nmzschema, user, OBJECT_TYPE.TABLE);
-			
-		} catch (SQLException e) {
-			throw new MojoExecutionException("スキーマ権限付与実行エラー", e);
-		} finally {
-			StatementUtil.close(stmt);
-			ConnectionUtil.close(conn);
-		}
-		 
- 	}
 
 	private boolean existsUser(Connection conn, String user) throws SQLException {
 		PreparedStatement stmt = null;

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -194,9 +194,7 @@ public class OracleDialect extends Dialect {
 			}
 
 			stmt.execute("CREATE USER "+ user + " IDENTIFIED BY "+ password + " DEFAULT TABLESPACE users");
-			String grantSql = "GRANT CREATE SESSION, UNLIMITED TABLESPACE, CREATE CLUSTER, CREATE INDEXTYPE, CREATE OPERATOR, " + 
-	                   "CREATE PROCEDURE, CREATE SEQUENCE, CREATE TABLE, CREATE TRIGGER, CREATE TYPE, SELECT ANY TABLE, " + 
-	                   "CREATE VIEW, CREATE ANY TABLE, CREATE SYNONYM, CREATE ANY DIRECTORY TO " + user;
+			String grantSql = "GRANT UNLIMITED TABLESPACE, EXP_FULL_DATABASE, IMP_FULL_DATABASE TO " + user;
 			stmt.execute(grantSql);
             System.err.println("GRANT文を実行しました:\n" + grantSql);
 
@@ -206,56 +204,6 @@ public class OracleDialect extends Dialect {
 			StatementUtil.close(stmt);
 			ConnectionUtil.close(conn);
 		}
-	}
-
-	@Override
-	public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-		
-        Connection conn = null;
-        PreparedStatement pstmt = null;
-        
-        try{
-        	conn = DriverManager.getConnection(url, admin, adminPassword);
-			PreparedStatement stmt = conn.prepareStatement("SELECT OBJECT_NAME FROM DBA_OBJECTS WHERE OBJECT_TYPE IN ('TABLE', 'VIEW', 'SEQUENCE') AND OWNER = ?");
-			stmt.setString(1, schema);
-			ResultSet rs = stmt.executeQuery();
-			while (rs.next()) {
-				String tableName = rs.getString("OBJECT_NAME");
-				// PreparedStatementで埋め込めるのはキーワードだけであり、スキーマ名やテーブル名には使用できないため。
-				String sql = "GRANT ALL ON " + schema + "." + tableName + " TO " + user;
-				conn.createStatement().execute(sql);
-			}
-		
-        } catch (SQLException e) {
-            throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);
-        } finally {
-        	StatementUtil.close(pstmt);
-            ConnectionUtil.close(conn);
-        }
-	}
-
-	private void createSchema(String schema, String user, String password, String admin, String adminPassword)  throws MojoExecutionException {
-		
-		Statement createUserStmt = null;
-		Connection conn = null;
-		
-		try{
-			conn = DriverManager.getConnection(url, admin, adminPassword);
-			createUserStmt= conn.createStatement();
-			createUserStmt.execute("CREATE USER "+ schema + " IDENTIFIED BY "+ schema + " DEFAULT TABLESPACE users");
-			String grantSql = "GRANT CREATE SESSION, UNLIMITED TABLESPACE, CREATE CLUSTER, CREATE INDEXTYPE, CREATE OPERATOR, " +
-					"CREATE PROCEDURE, CREATE SEQUENCE, CREATE TABLE, CREATE TRIGGER, CREATE TYPE, SELECT ANY TABLE, " +
-					"CREATE VIEW, CREATE ANY TABLE, CREATE SYNONYM, CREATE ANY DIRECTORY TO " + schema;
-			createUserStmt.execute(grantSql);
-			System.out.println("GRANT文を実行しました:\n" + grantSql);
-		
-		} catch (SQLException e) {
-			throw new MojoExecutionException("CREATE SCHEMA実行中にエラー", e);
-		} finally {
-			StatementUtil.close(createUserStmt);
-			ConnectionUtil.close(conn);
-		}
-
 	}
 
 	private boolean existsUser(Connection conn, String user) throws SQLException {
@@ -279,8 +227,9 @@ public class OracleDialect extends Dialect {
 		try {
 			conn = DriverManager.getConnection(url, adminUser, adminPassword);
 			// 指定スキーマがいなければ作成する。
+			// Oracleの場合はユーザ＝スキーマなのでcreateUserで作成。
 			if(!existsUser(conn, schema)) {
-				createSchema(schema, user, password, adminUser, adminPassword);
+				createUser(schema, password, adminUser, adminPassword);
 				return;
 			}
 		} catch (SQLException e) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -198,7 +198,7 @@ public class OracleDialect extends Dialect {
 			}
 
 			stmt.execute("CREATE USER "+ user + " IDENTIFIED BY "+ password + " DEFAULT TABLESPACE users");
-			String grantSql = "GRANT UNLIMITED TABLESPACE, EXP_FULL_DATABASE, IMP_FULL_DATABASE TO " + user;
+			String grantSql = "GRANT UNLIMITED TABLESPACE, DATAPUMP_EXP_FULL_DATABASE, DATAPUMP_IMP_FULL_DATABASE TO " + user;
 			stmt.execute(grantSql);
             System.err.println("GRANT文を実行しました:\n" + grantSql);
 

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/OracleDialect.java
@@ -141,6 +141,19 @@ public class OracleDialect extends Dialect {
 		BufferedReader reader = null;
 		try {
             createDirectory(user, password, dumpFile.getParentFile());
+            
+            // Oracleの場合はユーザのドロップと生成を行う。
+            Connection conn = null;
+            Statement stmt = null;
+            try {
+                conn = DriverManager.getConnection(url, user, password);
+                stmt = conn.createStatement();
+                stmt.execute("DROP USER " + schema + " CASCADE");
+            }finally{
+            	stmt.close();
+            	conn.close();
+            }
+            
 			ProcessBuilder pb = new ProcessBuilder(
 					"impdp",
 					user + "/" + password,

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/PostgresqlDialect.java
@@ -16,28 +16,32 @@
 
 package jp.co.tis.gsp.tools.dba.dialect;
 
-import jp.co.tis.gsp.tools.db.TypeMapper;
-import jp.co.tis.gsp.tools.dba.dialect.Dialect.OBJECT_TYPE;
-import jp.co.tis.gsp.tools.dba.util.ProcessUtil;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.seasar.extension.jdbc.gen.dialect.GenDialectRegistry;
 import org.seasar.extension.jdbc.util.ConnectionUtil;
-import org.seasar.framework.util.DriverManagerUtil;
 import org.seasar.framework.util.FileOutputStreamUtil;
 import org.seasar.framework.util.ResultSetUtil;
 import org.seasar.framework.util.StatementUtil;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.sql.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import jp.co.tis.gsp.tools.db.TypeMapper;
+import jp.co.tis.gsp.tools.dba.util.ProcessUtil;
 
 public class PostgresqlDialect extends Dialect {
     private static final List<String> USABLE_TYPE_NAMES = new ArrayList<String>();
@@ -208,27 +212,6 @@ public class PostgresqlDialect extends Dialect {
             throw new MojoExecutionException("CREATE USER実行中にエラー", e);
         } finally {
             StatementUtil.close(stmt);
-            ConnectionUtil.close(conn);
-        }
-    }
-
-    @Override
-    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-    	
-        Connection conn = null;
-        Statement stmt = null;
-        
-        try{
-        	conn = DriverManager.getConnection(url, admin, adminPassword);
-        	stmt = conn.createStatement();
-        	stmt.execute("GRANT ALL ON SCHEMA " + schema + " TO " + user); // スキーマ自体への権限
-        	stmt.execute("GRANT ALL ON ALL TABLES IN SCHEMA " + schema + " TO " + user); // テーブルとビュー
-        	stmt.execute("GRANT ALL ON ALL SEQUENCES IN SCHEMA " + schema + " TO " + user); // シーケンス
-        
-        } catch (SQLException e) {
-            throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);
-        } finally {
-        	StatementUtil.close(stmt);
             ConnectionUtil.close(conn);
         }
     }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -239,41 +239,6 @@ public class SqlserverDialect extends Dialect {
         }
     }
 
-    /**
-     * ユーザ名とスキーマ名が不一致の時、そのスキーマ内の全オブジェクトに対して
-     * オブジェクト権限を付与する。
-     * SQL Serverは自分で新規作成したスキーマならスキーマごど権限を任意のユーザに委譲できるが、
-     * dbo(ユーザ新規作成時のデフォルトスキーマ)などの特殊なスキーマだけは
-     * スキーマの権限移譲ができないため、このように対応する必要があった。
-     * @param conn DBコネクション
-     * @param schema スキーマ名
-     * @param user ユーザ名
-     * @throws SQLException SQL実行時のエラー
-     */
-    @Override
-    public void grantAllToUser(String schema, String user, String password, String admin, String adminPassword) throws MojoExecutionException {
-    	
-        Connection conn = null;
-    	Statement stmt = null;
-    	
-    	try{    	
-	    	conn = DriverManager.getConnection(url, admin, adminPassword);
-	    	stmt = conn.createStatement();
-	        ResultSet rs = stmt.executeQuery("SELECT NAME FROM SYS.OBJECTS WHERE SCHEMA_ID = SCHEMA_ID('" + schema + "') AND TYPE IN ('U','V')");
-	        StringBuilder sb = new StringBuilder();
-	        Statement grantStmt = conn.createStatement();
-	        while (rs.next()) {
-	            grantStmt.execute("GRANT ALL ON " + schema + "." + rs.getString("NAME") + " TO " + user);
-	        }
-        
-        } catch (SQLException e) {
-            throw new MojoExecutionException("権限付与処理 実行中にエラー: ", e);
-        } finally {
-        	StatementUtil.close(stmt);
-            ConnectionUtil.close(conn);
-        }
-    }
-
     private String getUrlReplaceDatabaseName(String newDatabaseName) {
         String[] properties = url.split(";");
         String newUrl = properties[0];

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExecuteDdlMojo.java
@@ -109,9 +109,6 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 			throw new MojoExecutionException("SQL実行中にエラーが発生しました:", e);
 		}
 
-		// DBユーザにスキーマオブジェクトの権限を付与する
-        dialect.grantAllToUser(schema, user, password, adminUser, adminPassword);
-
         // コネクション解放
         ConnectionUtil.close(conn);
 	}
@@ -157,7 +154,7 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
 
     private void executeBySqlFiles(File...sqlFiles) throws SQLException, IOException, MojoExecutionException {
         if (conn == null || conn.isClosed()) {
-            setConnection();
+        	conn = DriverManager.getConnection(url, user, password);
         }
 
         successfulStatements = 0;
@@ -181,17 +178,4 @@ public class ExecuteDdlMojo extends AbstractDbaMojo {
                 + " SQL statements executed successfully");
     }
 
-    /**
-     * ユーザ名とスキーマ名に応じて適切なコネクションを設定する。
-     * データベースがOracleでかつユーザ名とスキーマ名が異なる時、
-     * DDLの実行に管理者ユーザでのログインが必要なため。
-     * @throws SQLException SQLエラー
-     */
-    private void setConnection() throws SQLException {
-        if (schema.equals(user)) {
-            conn = DriverManager.getConnection(url, user, password);
-        } else {
-            conn = DriverManager.getConnection(url, adminUser, adminPassword);
-        }
-    }
 }


### PR DESCRIPTION
以下の修正を実施。
- ユーザ名≠スキーマ名の時に、adminUserでDDLを流す仕組みを削除。
- 上記に伴い、後付けで権限付与していたgrantAllToUser()を除去。
- Oracleのインポート時、ALL_OBJECTSテーブルより指定スキーマが所有者のオブジェクトを全部消す。
- OracleのdropAll時にcreateSchema()というメソッドでスキーマを作成していたが、createUser()と同じだったので、createUser()に寄せた。
- H2のエクスポート時に、Dropオプションを付与する。