### PR TITLE
PostgreslqのPKの列定義順序の修正

### DIFF
--- a/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
+++ b/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
@@ -11,4 +11,3 @@ CREATE <#if index.type=2>UNIQUE </#if>INDEX ${index.name} ON <#if entity.schema?
   ${column.name}<#if column_has_next>,</#if>
 </#foreach>
 );
-</#if>

--- a/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
+++ b/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createIndex.ftl
@@ -1,7 +1,7 @@
-<#-- postgresqlではalter table句で複合主キー制約を設定できないため、主キーの定義はcreateTableで行う。 -->
 <#-- postgresqlではindexは常に指定テーブルと同じスキーマに作成されるためスキーマ修飾はなし -->
-<#if !index.isPrimaryKey()>
-<#if index.type=1>
+<#if index.isPrimaryKey()>
+ALTER TABLE <#if entity.schema??>${entity.schema}</#if>${entity.name} ADD CONSTRAINT ${index.name!} PRIMARY KEY
+<#elseif index.type=1>
 ALTER TABLE <#if entity.schema??>${entity.schema}</#if>${entity.name} ADD CONSTRAINT ${index.name!} UNIQUE
 <#elseif index.type=2 || index.type=3>
 CREATE <#if index.type=2>UNIQUE </#if>INDEX ${index.name} ON <#if entity.schema??>${entity.schema}</#if>${entity.name}

--- a/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createTable.ftl
+++ b/src/main/resources/jp/co/tis/gsp/tools/db/template/postgresql/createTable.ftl
@@ -2,12 +2,8 @@
 <#-- Postgresqlは複数主キーをalter tableで指定できないため、こちらで設定する。 -->
 CREATE TABLE <#if entity.schema??>${entity.schema}</#if>${entity.name} (
 <#foreach column in entity.columnList>
-  ${column.name} ${column.dataType}<#if column.length != 0>(${column.length}<#if column.scale!=0>,${column.scale}</#if>)</#if><#if column.isArray()> ARRAY</#if><#if !column.isNullable()> NOT NULL</#if><#if column.defaultValue?has_content> DEFAULT ${column.defaultValue}</#if><#if column_has_next>,<#else><#if entity.havePrimaryKey()>,</#if></#if>
+  ${column.name} ${column.dataType}<#if column.length != 0>(${column.length}<#if column.scale!=0>,${column.scale}</#if>)</#if><#if column.isArray()> ARRAY</#if><#if !column.isNullable()> NOT NULL</#if><#if column.defaultValue?has_content> DEFAULT ${column.defaultValue}</#if><#if column_has_next>,</#if>
 </#foreach>
-<#if entity.havePrimaryKey()>
-<#assign isFirst = "true" />
-  PRIMARY KEY (<#foreach column in entity.columnList><#if column.isPrimaryKey()><#if isFirst!="true">, </#if>${column.name}<#assign isFirst = "false" /></#if></#foreach>)
-</#if>
 );
 <#if entity.label?has_content>
 COMMENT ON table <#if entity.schema??>${entity.schema}</#if>${entity.name} is '${entity.label}';


### PR DESCRIPTION
[postgresqlのPK定義方法変更](https://github.com/coastland/gsp-dba-maven-plugin/pull/75)のプルリクを受けて、PostgresqlのcreateIndex.ftlとcreateTable.ftlを修正。

- createTable.ftlよりプライマリキーの定義を削除。
- createIndex.ftlにプライマリキーの定義を追加。index情報のカラム情報よりPK列定義を行うように修正。