### PR TITLE
JPA対応:Oracle以外はGenerationTypeをIDENTITYに設定。

### DIFF
--- a/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
+++ b/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
@@ -1,10 +1,27 @@
+<#function isForeignKey attr associationModelList>
+  <#list associationModelList as asso>
+    <#if asso.joinColumnModel?? && asso.joinColumnModel.name == attr.columnName>
+      <#return true>
+    </#if>
+    <#if asso.joinColumnsModel??>
+      <#list asso.joinColumnsModel.joinColumnModelList as joinColumn>
+        <#if joinColumn.name == attr.columnName>
+          <#return true>
+        </#if>
+      </#list>
+    </#if>
+  </#list>
+  <#return false>
+</#function>
 <#macro printAttrAnnotations tableName attr>
   <#if attr.id>
     @Id
     <#if attr.generationType??>
-    @GeneratedValue(generator = "generator", strategy = GenerationType.AUTO)
       <#if attr.generationType == "SEQUENCE">
+    @GeneratedValue(generator = "generator", strategy = GenerationType.AUTO)
     @SequenceGenerator(name = "generator", sequenceName = "${attr.columnName}_SEQ", initialValue = ${attr.initialValue}, allocationSize = ${attr.allocationSize})
+      <#else>
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
       </#if>
     </#if>
   </#if>
@@ -17,7 +34,7 @@
   <#if attr.version>
     @Version
   </#if>
-    @Column(<#if attr.columnName??>name = "${attr.columnName}", </#if><#if attr.columnDefinition??>columnDefinition = "${attr.columnDefinition}", <#else><#if attr.length??>length = ${attr.length}, </#if><#if attr.precision??>precision = ${attr.precision}, </#if><#if attr.scale??>scale = ${attr.scale}, </#if></#if>nullable = ${attr.nullable?string}, unique = ${attr.unique?string})
+    @Column(<#if attr.columnName??>name = "${attr.columnName}", </#if><#if attr.columnDefinition??>columnDefinition = "${attr.columnDefinition}", <#else><#if attr.length??>length = ${attr.length}, </#if><#if attr.precision??>precision = ${attr.precision}, </#if><#if attr.scale??>scale = ${attr.scale}, </#if></#if>nullable = ${attr.nullable?string}, unique = ${attr.unique?string} <#if isForeignKey(attr, associationModelList)>, insertable = false, updatable = false</#if>)
 </#macro>
 <#macro printAssoAnnotations asso>
     @${asso.associationType.annotation.simpleName}<#if asso.mappedBy??>(mappedBy = "${asso.mappedBy}")</#if>

--- a/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
+++ b/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
@@ -1,3 +1,5 @@
+<#-- 引数で指定されたカラムが、関連モデルに含まれるかどうかを判定するファンクション -->
+<#-- @JoinColumnと@JoinColumnsに指定したカラム名が存在するかどうかで判定する。 -->
 <#function isForeignKey attr associationModelList>
   <#list associationModelList as asso>
     <#if asso.joinColumnModel?? && asso.joinColumnModel.name == attr.columnName>


### PR DESCRIPTION
下記の対応を行いました。

- GenerationTypeの設定
    - Oracleの時は@SequenceGeneratorが出力される。
    - Oracle以外の時は、ゴミとなっているgenerator属性は不要なので削除、GenerationTypeをIDENTITYに設定。
- 関連オブジェクトの結合カラム（外部キー）として定義されているフィールドに対して、「insertable=false, updateble=false」を付与する。