### PR TITLE
JPA(Eclipselink)仕様に合わせて、エンティティのシーケンス属性の値を修正。

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/s2jdbc/gen/GspAttributeDescFactoryImpl.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/s2jdbc/gen/GspAttributeDescFactoryImpl.java
@@ -44,6 +44,12 @@ public class GspAttributeDescFactoryImpl extends AttributeDescFactoryImpl {
 
         // PrimaryKeyでも外部キーになっているものは、ID生成しないので対象から外す。
         if (attributeDesc.getGenerationType() != null) {
+        
+        	// JPA仕様を考慮し、GSPで生成されるシーケンスの増分値１と合わせる
+            if(attributeDesc.getGenerationType().equals(GenerationType.SEQUENCE)){
+            	attributeDesc.setAllocationSize(1);
+            }
+        	
             for (DbForeignKeyMeta foreignKeyMeta : tableMeta.getForeignKeyMetaList()) {
                 if (foreignKeyMeta.getForeignKeyColumnNameList().contains(columnMeta.getName())) {
                     attributeDesc.setGenerationType(null);

--- a/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
+++ b/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
@@ -20,8 +20,8 @@
     @Id
     <#if attr.generationType??>
       <#if attr.generationType == "SEQUENCE">
-    @GeneratedValue(generator = "generator", strategy = GenerationType.AUTO)
-    @SequenceGenerator(name = "generator", sequenceName = "${attr.columnName}_SEQ", initialValue = ${attr.initialValue}, allocationSize = ${attr.allocationSize})
+    @GeneratedValue(generator = "${attr.columnName}_SEQ", strategy = GenerationType.AUTO)
+    @SequenceGenerator(name = "${attr.columnName}_SEQ", sequenceName = "${attr.columnName}_SEQ", initialValue = ${attr.initialValue}, allocationSize = ${attr.allocationSize})
       <#else>
     @GeneratedValue(strategy = GenerationType.IDENTITY)
       </#if>


### PR DESCRIPTION
- 下記のエンティティ生成処理の修正を実施。
    - ジェネレータの名前をDBのシーケンス名と合わせ、エンティティ間でジェネレータ名が被らないように修正。  
[Eclipselink シーケンス仕様](https://wiki.eclipse.org/EclipseLink/Examples/JPA/PrimaryKey#Specifying_a_Sequence)
    - @SequenceGeneratorのallocationSizeをDBのシーケンス増分値（現状GSPでは1）に一旦合わせる対応を入れる。