### PR TITLE
JPAテスト:persistence.xmlのプロパティファイル置換変数対応。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
                                 <goal>gsp-dba:generate-ddl</goal>
                                 <goal>gsp-dba:execute-ddl</goal>
                                 <goal>gsp-dba:generate-entity</goal>
+                                <goal>resources:testResources</goal>
                                 <goal>test</goal>
                             </goals>
                             <properties>

--- a/src/it/simple-jpa-test/pom.xml
+++ b/src/it/simple-jpa-test/pom.xml
@@ -99,6 +99,15 @@
 		</dependency>
 	</dependencies>
 	<build>
+		<filters>
+			<filter>../../test/resources/jdbc_test.properties</filter>
+		</filters>
+		<testResources>
+			<testResource>
+				<directory>src/test/resources</directory>
+				<filtering>true</filtering>
+			</testResource>
+		</testResources>
 		<plugins>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/src/it/simple-jpa-test/src/test/resources/META-INF/persistence.xml
+++ b/src/it/simple-jpa-test/src/test/resources/META-INF/persistence.xml
@@ -10,10 +10,10 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jar-file>file:../classes</jar-file>
 		<properties>
-			<property name="javax.persistence.jdbc.driver" value="org.h2.Driver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:h2:./src/test/gsp_test" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="gsptest" />
+			<property name="javax.persistence.jdbc.driver" value="${h2.jdbcDriver}" />
+			<property name="javax.persistence.jdbc.url" value="${h2.url}" />
+			<property name="javax.persistence.jdbc.user" value="${h2.user}" />
+			<property name="javax.persistence.jdbc.password" value="${h2.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>
@@ -24,10 +24,10 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jar-file>file:../classes</jar-file>
 		<properties>
-			<property name="javax.persistence.jdbc.driver" value="oracle.jdbc.driver.OracleDriver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:oracle:thin:@localhost:1521/xe" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="gsptest" />
+			<property name="javax.persistence.jdbc.driver" value="${oracle.jdbcDriver}" />
+			<property name="javax.persistence.jdbc.url" value="${oracle.url}" />
+			<property name="javax.persistence.jdbc.user" value="${oracle.user}" />
+			<property name="javax.persistence.jdbc.password" value="${oracle.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>
@@ -38,10 +38,10 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jar-file>file:../classes</jar-file>
 		<properties>
-			<property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/gsptest" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="gsptest" />
+			<property name="javax.persistence.jdbc.driver" value="${mysql.jdbcDriver}" />
+			<property name="javax.persistence.jdbc.url" value="${mysql.url}" />
+			<property name="javax.persistence.jdbc.user" value="${mysql.user}" />
+			<property name="javax.persistence.jdbc.password" value="${mysql.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>
@@ -52,10 +52,10 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jar-file>file:../classes</jar-file>
 		<properties>
-			<property name="javax.persistence.jdbc.driver" value="com.ibm.db2.jcc.DB2Driver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:db2://localhost:50000/gsptest" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="Gsptest123" />
+			<property name="javax.persistence.jdbc.driver" value="${db2.jdbcDriver}" />
+			<property name="javax.persistence.jdbc.url" value="${db2.url}" />
+			<property name="javax.persistence.jdbc.user" value="${db2.user}" />
+			<property name="javax.persistence.jdbc.password" value="${db2.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>
@@ -67,11 +67,11 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<jar-file>file:../classes</jar-file>
 		<properties>
 			<property name="javax.persistence.jdbc.driver"
-				value="com.microsoft.sqlserver.jdbc.SQLServerDriver" />
+				value="${sqlserver.jdbcDriver}" />
 			<property name="javax.persistence.jdbc.url"
-				value="jdbc:sqlserver://localhost:1433;database=gsptest" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="Gsptest123" />
+				value="${sqlserver.url}" />
+			<property name="javax.persistence.jdbc.user" value="${sqlserver.user}" />
+			<property name="javax.persistence.jdbc.password" value="${sqlserver.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>
@@ -82,10 +82,10 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jar-file>file:../classes</jar-file>
 		<properties>
-			<property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver" />
-			<property name="javax.persistence.jdbc.url" value="jdbc:postgresql://localhost:5432/gsptest" />
-			<property name="javax.persistence.jdbc.user" value="gsptest" />
-			<property name="javax.persistence.jdbc.password" value="gsptest" />
+			<property name="javax.persistence.jdbc.driver" value="${postgresql.jdbcDriver}" />
+			<property name="javax.persistence.jdbc.url" value="${postgresql.url}" />
+			<property name="javax.persistence.jdbc.user" value="${postgresql.user}" />
+			<property name="javax.persistence.jdbc.password" value="${postgresql.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />
 			<property name="eclipselink.logging.level" value="ALL" />
 		</properties>


### PR DESCRIPTION
JPAのテスト(integration-test)で、persistence.xmlに定義する各ＤＢの接続情報などを、テストのjdbc_test.proptiesファイルから生成するように変更。