### PR TITLE
ddlとcsvをパッケージしてjarにする機能を追加

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
@@ -54,11 +54,11 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
     @Parameter
     protected String adminPassword;
     
-	/**
+    /**
      * The name of database user.
-	 */
+     */
     @Parameter(required = true)
-	protected String user;
+    protected String user;
 
     /**
      * The password of database user;
@@ -66,18 +66,18 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
     @Parameter
     protected String password;
 
-	/**
-	 * The name of schema.
-	 */
+    /**
+     * The name of schema.
+     */
     @Parameter
-	protected String schema;
+    protected String schema;
 
 
-	/**
-	 * dumpFile
-	 */
+    /**
+     * dumpFile
+     */
     @Parameter
-	protected String dmpFile;
+    protected String dmpFile;
 
     /**
      * additional Dialect names.<br/>
@@ -134,22 +134,22 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
             if (url.split(":")[1].equals("h2")) {
                 schema = "PUBLIC";
             } else if(url.split(":")[1].equals("mysql")) {
-            	try {
-            		//データベース名をスキーマ名としてセット
-					Connection conn = DriverManager.getConnection(url, adminUser, adminPassword);
-					schema = dialect.normalizeSchemaName(conn.getCatalog());
-				} catch (SQLException e) {
-					throw new MojoExecutionException("MySQL:データベース名の取得に失敗しました。", e);
-				}
+                try {
+                    //データベース名をスキーマ名としてセット
+                    Connection conn = DriverManager.getConnection(url, adminUser, adminPassword);
+                    schema = dialect.normalizeSchemaName(conn.getCatalog());
+                } catch (SQLException e) {
+                    throw new MojoExecutionException("MySQL:データベース名の取得に失敗しました。", e);
+                }
             }else {
                 schema = user;
             }
         }else{
-        	if(url.split(":")[1].equals("mysql")) {
-        		throw new MojoExecutionException("MySQLではスキーマを指定することは出来ません。");
-        	}
-        	
-        	schema = dialect.normalizeSchemaName(schema);
+            if(url.split(":")[1].equals("mysql")) {
+                throw new MojoExecutionException("MySQLではスキーマを指定することは出来ません。");
+            }
+            
+            schema = dialect.normalizeSchemaName(schema);
         }
         
         executeMojoSpec();
@@ -162,4 +162,17 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
      * @throws MojoFailureException @{@link org.apache.maven.plugin.Mojo#execute()}
      */
     protected abstract void executeMojoSpec() throws MojoExecutionException, MojoFailureException;
+    
+    protected void copyParameter(AbstractDbaMojo mojo) {
+        mojo.adminPassword = adminPassword;
+        mojo.adminUser = adminUser;
+        mojo.driver = driver;
+        mojo.password = password;
+        mojo.schema = schema;
+        mojo.user = user;
+        mojo.url = url;
+        mojo.onError = onError;
+        mojo.dmpFile = dmpFile;
+        mojo.optionalDialects = optionalDialects;
+    }
 }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/AbstractDbaMojo.java
@@ -54,11 +54,11 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
     @Parameter
     protected String adminPassword;
     
-    /**
+	/**
      * The name of database user.
-     */
+	 */
     @Parameter(required = true)
-    protected String user;
+	protected String user;
 
     /**
      * The password of database user;
@@ -66,18 +66,18 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
     @Parameter
     protected String password;
 
-    /**
-     * The name of schema.
-     */
+	/**
+	 * The name of schema.
+	 */
     @Parameter
-    protected String schema;
+	protected String schema;
 
 
-    /**
-     * dumpFile
-     */
+	/**
+	 * dumpFile
+	 */
     @Parameter
-    protected String dmpFile;
+	protected String dmpFile;
 
     /**
      * additional Dialect names.<br/>
@@ -134,22 +134,22 @@ public abstract class AbstractDbaMojo extends AbstractMojo {
             if (url.split(":")[1].equals("h2")) {
                 schema = "PUBLIC";
             } else if(url.split(":")[1].equals("mysql")) {
-                try {
-                    //データベース名をスキーマ名としてセット
-                    Connection conn = DriverManager.getConnection(url, adminUser, adminPassword);
-                    schema = dialect.normalizeSchemaName(conn.getCatalog());
-                } catch (SQLException e) {
-                    throw new MojoExecutionException("MySQL:データベース名の取得に失敗しました。", e);
-                }
+            	try {
+            		//データベース名をスキーマ名としてセット
+					Connection conn = DriverManager.getConnection(url, adminUser, adminPassword);
+					schema = dialect.normalizeSchemaName(conn.getCatalog());
+				} catch (SQLException e) {
+					throw new MojoExecutionException("MySQL:データベース名の取得に失敗しました。", e);
+				}
             }else {
                 schema = user;
             }
         }else{
-            if(url.split(":")[1].equals("mysql")) {
-                throw new MojoExecutionException("MySQLではスキーマを指定することは出来ません。");
-            }
-            
-            schema = dialect.normalizeSchemaName(schema);
+        	if(url.split(":")[1].equals("mysql")) {
+        		throw new MojoExecutionException("MySQLではスキーマを指定することは出来ません。");
+        	}
+        	
+        	schema = dialect.normalizeSchemaName(schema);
         }
         
         executeMojoSpec();

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExportSchemaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ExportSchemaMojo.java
@@ -17,13 +17,29 @@
 package jp.co.tis.gsp.tools.dba.mojo;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
-
-import jp.co.tis.gsp.tools.dba.dialect.Dialect;
-import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -32,6 +48,17 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.seasar.extension.jdbc.util.ConnectionUtil;
+import org.seasar.framework.util.DriverManagerUtil;
+import org.seasar.framework.util.OutputStreamUtil;
+import org.seasar.framework.util.ResultSetUtil;
+import org.seasar.framework.util.StatementUtil;
+
+import com.csvreader.CsvWriter;
+
+import jp.co.tis.gsp.tools.dba.dialect.Dialect;
+import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
+import jp.co.tis.gsp.tools.dba.util.DialectUtil;
 
 /**
  * export-schema.
@@ -43,43 +70,294 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 @Mojo(name = "export-schema", requiresProject = true)
 public class ExportSchemaMojo extends AbstractDbaMojo {
 
-    @Parameter(defaultValue = "target/dump")
-	protected File outputDirectory;
+    @Parameter(defaultValue = "target/export")
+    protected File outputDirectory;
 
-    @Component( role = Archiver.class, hint = "jar" )
+    @Parameter(defaultValue = "target/ddl", required = true)
+    protected File ddlDirectory;
+
+    @Parameter(required = true)
+    protected File extraDdlDirectory;
+
+    @Parameter
+    protected Map<String, String> specifiedEncodingTables;
+
+    @Component(role = Archiver.class, hint = "jar")
     protected JarArchiver jarArchiver;
 
     @Component
     private MavenProject project;
 
-	@Override
-	protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
-		Dialect dialect = DialectFactory.getDialect(url, driver);
-		if (!outputDirectory.exists()) {
-			try {
-				FileUtils.forceMkdir(outputDirectory);
-			} catch (IOException e) {
-				throw new MojoExecutionException("Can't create dump output directory." + outputDirectory, e);
-			}
-		}
-		File exportFile = new File(outputDirectory, StringUtils.defaultIfEmpty(dmpFile, schema + ".dmp"));
-		getLog().info(schema+"スキーマのExportを開始します。:" + exportFile);
-		try {
-			dialect.exportSchema(adminUser, adminPassword, schema, exportFile);
+    // CSVデータ出力先(Mavenパラメータとする必要がない。内部的利用に限定。)
+    protected File dataDirectory;
 
-		} catch (Exception e) {
-			throw new MojoExecutionException("データのExportに失敗しました。 ", e);
-		}
-        jarArchiver.addFile(exportFile, exportFile.getName());
+    // デフォルト設定値
+    final Charset SJIS = Charset.forName("Windows-31J");
+    final SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd");
+    final SimpleDateFormat sdfTimestamp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    /*** jar内のディレクトリ構造 **/
+    private final String DDL_DIR_NAME = "ddlDirectory";
+    private final String EXTRADDL_DIR_NAME = "extraDdlDirecotry";
+    private final String DATA_DIR_NAME = "dataDirectory";
+
+    @Override
+    protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
+
+        Dialect dialect = DialectFactory.getDialect(url, driver);
+        DialectUtil.setDialect(dialect);
+
+        if (!outputDirectory.exists()) {
+            try {
+                FileUtils.forceMkdir(outputDirectory);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Can't create dump output directory." + outputDirectory, e);
+            }
+        }
+
+        // CSVデータ出力ディレクトリ
+        // CSV出力先はoutputDirectoryの直下にdataDirectory固定
+        dataDirectory = new File(outputDirectory, DATA_DIR_NAME);
+        if (!dataDirectory.exists()) {
+            try {
+                FileUtils.forceMkdir(dataDirectory);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Can't create dump output directory." + dataDirectory, e);
+            }
+        }
+
+        // DBのテーブルからCSVデータをCSVデータ出力ディレクトリに出力。
+        exportCSV();
+
+        // DDL、extraDDLをoutputDirectoryにコピー。
+        collectDdl();
+
+        // DDL、extraDDl、csvデータをjarでpack。
+        jarArchiver.addDirectory(outputDirectory);
         jarArchiver.setDestFile(new File(outputDirectory, jarName()));
+
         try {
             jarArchiver.createArchive();
-        } catch(IOException e) {
+        } catch (IOException e) {
             throw new MojoExecutionException("アーカイブに失敗しました。", e);
         }
-		getLog().info(schema+"スキーマのExport完了 ");
-	}
+        getLog().info(schema + "Export完了 ");
+    }
 
+    /**
+     * DDLと追加DDLを出力ディレクトリに収集します。
+     * 
+     * @return
+     * @throws MojoExecutionException
+     */
+    private void collectDdl() throws MojoExecutionException {
+        try {
+            FileUtils.copyDirectory(ddlDirectory, new File(outputDirectory, DDL_DIR_NAME));
+            FileUtils.copyDirectory(extraDdlDirectory, new File(outputDirectory, EXTRADDL_DIR_NAME));
+        } catch (IOException e) {
+            throw new MojoExecutionException("DDLとデータファイルのコピーに失敗しました。", e);
+        }
+    }
+
+    /**
+     * 接続スキーマの全テーブルデータをCSVファイルに出力します。
+     * 
+     * @throws MojoExecutionException
+     */
+    private void exportCSV() throws MojoExecutionException {
+
+        DriverManagerUtil.registerDriver(driver);
+        Dialect dialect = DialectUtil.getDialect();
+        Connection conn = null;
+        Charset charset;
+
+        try {
+            conn = DriverManager.getConnection(url, user, password);
+
+            final List<String> tableList = getTableNames(conn.getMetaData(), dialect.normalizeSchemaName(schema),
+                    new String[] { "TABLE" });
+
+            for (String tableName : tableList) {
+
+                if (specifiedEncodingTables != null && specifiedEncodingTables.containsKey(tableName)) {
+                    String encoding = (String) specifiedEncodingTables.get(tableName);
+                    charset = Charset.forName(encoding);
+                    getLog().info(" -- encoding:" + encoding);
+                } else {
+                    charset = SJIS;
+                }
+
+                writeToCSV(conn, tableName, new File(dataDirectory, tableName + ".csv"), charset);
+            }
+
+        } catch (SQLException e) {
+            getLog().error("DBに接続できませんでした。driverおよびurlの設定が正しいか確認してください");
+            throw new MojoExecutionException("", e);
+        } catch (FileNotFoundException e) {
+            getLog().error("CSVファイルの出力中にエラーが発生しました。", e);
+            throw new MojoExecutionException("", e);
+        } catch (IOException e) {
+            getLog().error("CSVファイルの出力中にエラーが発生しました。", e);
+        } finally {
+            ConnectionUtil.close(conn);
+        }
+    }
+
+    /**
+     * SELECT文の結果をCSVファイルにカラム名ヘッダー付きで出力します。
+     * 
+     * @param metaData
+     * @param resultSet
+     * @param csvFile
+     * @param charset
+     * @throws SQLException
+     * @throws IOException
+     */
+    public void writeToCSV(Connection conn, String tableName, File csvFile, Charset charset)
+            throws SQLException, IOException {
+
+        Dialect dialect = DialectUtil.getDialect();
+        Statement stmt = null;
+        ResultSet resultSet = null;
+
+        OutputStream out = new FileOutputStream(csvFile);
+        String[] columnHeaders;
+        String[] values = null;
+        CsvWriter csvWriter = null;
+
+        try {
+            stmt = conn.createStatement();
+            resultSet = stmt.executeQuery("SELECT * FROM " + tableName + getOrderString(conn.getMetaData(), tableName));
+            ResultSetMetaData meta = resultSet.getMetaData();
+
+            csvWriter = new CsvWriter(out, ',', charset);
+            csvWriter.setForceQualifier(true);
+            csvWriter.setRecordDelimiter('\n');
+
+            // カラムヘッダーの出力
+            int columnCount = meta.getColumnCount();
+            columnHeaders = new String[columnCount];
+            for (int i = 1; i <= columnCount; i++) {
+                columnHeaders[i - 1] = meta.getColumnName(i);
+            }
+            csvWriter.writeRecord(columnHeaders);
+
+            // データの出力
+            while (resultSet.next()) {
+                values = new String[columnCount];
+                for (int i = 1; i <= columnCount; i++) {
+                    resultSet.getString(i);
+                    int sqlType = dialect.guessType(conn, schema, tableName, meta.getColumnName(i));
+                    values[i - 1] = convert(resultSet, i, sqlType);
+                }
+                csvWriter.writeRecord(values);
+            }
+        } finally {
+            csvWriter.flush();
+            csvWriter.close();
+
+            ResultSetUtil.close(resultSet);
+            StatementUtil.close(stmt);
+            OutputStreamUtil.close(out);
+        }
+
+    }
+
+    /**
+     * SQLのタイプに応じて値の書式を変換します。
+     * 
+     * @param resultSet
+     * @param meta
+     * @param index
+     * @return
+     * @throws SQLException
+     */
+    private String convert(ResultSet resultSet, int index, int sqlType) throws SQLException {
+
+        String value = "";
+        switch (sqlType) {
+        case Types.DATE:
+            Date date = resultSet.getDate(index);
+            if (date != null) {
+                value = sdfDate.format(date);
+            }
+            break;
+        case Types.TIMESTAMP:
+            Timestamp timestamp = resultSet.getTimestamp(index);
+            if (timestamp != null) {
+                value = sdfTimestamp.format(timestamp);
+            }
+            break;
+        default:
+            value = resultSet.getString(index);
+            break;
+        }
+
+        return value;
+    }
+
+    /**
+     * 指定スキーマに属するテーブル名のリストを取得します。
+     * 
+     * @param metaData
+     * @param normalizedSchemaName
+     * @param types
+     * @return
+     * @throws SQLException
+     */
+    public List<String> getTableNames(DatabaseMetaData metaData, String normalizedSchemaName, String[] types)
+            throws SQLException {
+        List<String> allNames = new ArrayList<String>();
+        ResultSet rs = null;
+        try {
+            rs = metaData.getTables(null, normalizedSchemaName, "%", types);
+            while (rs.next()) {
+                allNames.add(rs.getString("TABLE_NAME"));
+            }
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+        }
+        return allNames;
+    }
+
+    /**
+     * 主キー項目でソートをかけるorderBy文字列を生成します。
+     * 
+     * @param meta
+     * @param tableName
+     * @return
+     * @throws SQLException
+     */
+    private String getOrderString(DatabaseMetaData meta, String tableName) throws SQLException {
+        String orderByString = "";
+        ResultSet rs = null;
+        Map<Short, String> keyMap = new TreeMap<Short, String>();
+
+        try {
+            rs = meta.getPrimaryKeys(null, schema, tableName);
+            while (rs.next()) {
+                keyMap.put(rs.getShort("KEY_SEQ"), rs.getString("COLUMN_NAME"));
+            }
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+        }
+
+        Set<Short> keySet = keyMap.keySet();
+
+        if (keySet.size() > 0) {
+            orderByString = " ORDER BY";
+            for (Short key : keySet) {
+                String preStr = key.shortValue() > 1 ? "," : " ";
+                orderByString += (preStr + keyMap.get(key));
+            }
+        }
+
+        return orderByString;
+    }
 
     private String jarName() {
         if (project == null) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
@@ -18,13 +18,12 @@ package jp.co.tis.gsp.tools.dba.mojo;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
@@ -51,7 +50,7 @@ import jp.co.tis.gsp.tools.dba.dialect.DialectFactory;
 @Mojo(name = "import-schema", requiresProject = true)
 public class ImportSchemaMojo extends AbstractDbaMojo {
     @Parameter(defaultValue = "target/dump")
-	protected File inputDirectory;
+    protected File inputDirectory;
 
     @Component
     private MavenProject project;
@@ -70,12 +69,22 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
 
     @Parameter(defaultValue = "${project.version}")
     protected String version;
+    
+    /*** LoadData Param **/
+    @Parameter
+    @SuppressWarnings("rawtypes")
+    protected Map specifiedEncodingFiles;
+
+    /*** jar内のディレクトリ構造 **/
+    private final String DDL_DIR_NAME = "ddlDirectory";
+    private final String EXTRADDL_DIR_NAME = "extraDdlDirecotry";
+    private final String DATA_DIR_NAME = "dataDirectory";
 
     @Override
-	protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
-		Dialect dialect = DialectFactory.getDialect(url, driver);
-		dialect.createUser(user, password, adminUser, adminPassword);
-		dialect.dropAll(user, password, adminUser, adminPassword, schema);
+    protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
+        Dialect dialect = DialectFactory.getDialect(url, driver);
+        dialect.createUser(user, password, adminUser, adminPassword);
+        dialect.dropAll(user, password, adminUser, adminPassword, schema);
 
         Artifact artifact = repositorySystem.createArtifact(groupId, artifactId, version, "jar");
         ArtifactResolutionRequest schemaArtifactRequest = new ArtifactResolutionRequest()
@@ -87,27 +96,69 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
                 getLog().error("インポートするダンプファイルの取得に失敗しました。", e);
             }
         }
-
-        JarFile jarFile = JarFileUtil.create(new File(localRepository.getBasedir(),
-                localRepository.pathOf(artifact)));
-        String importFilename = StringUtils.defaultIfEmpty(dmpFile, schema + ".dmp");
-        InputStream is = null;
-        File importFile = new File(inputDirectory, importFilename);
-        JarEntry jarEntry = jarFile.getJarEntry(importFilename);
-        if (jarEntry == null)
-            throw new MojoExecutionException(importFilename + " is not found?");
+        
+        // ddl及びdataディレクトリの取り出し
         try {
-            is = jarFile.getInputStream(jarEntry);
-            FileUtils.copyInputStreamToFile(is, importFile);
-        } catch(IOException e) {
+            if (!inputDirectory.exists()) {
+                try {
+                    FileUtils.forceMkdir(inputDirectory);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Can't create dump output directory." + inputDirectory, e);
+                }
+            }
+
+            JarFile jarFile = JarFileUtil
+                    .create(new File(localRepository.getBasedir(), localRepository.pathOf(artifact)));
+            allExtract(jarFile, inputDirectory.getPath());
+        } catch (IOException e) {
             throw new MojoExecutionException("", e);
-        } finally {
-            IOUtils.closeQuietly(is);
         }
 
-		getLog().info("スキーマのインポートを開始します。:" + importFile);
-		dialect.importSchema(adminUser, adminPassword, schema, importFile);
-		getLog().info("スキーマのインポートを終了しました");
-	}
+        getLog().info("スキーマのインポートを開始します。:");
+        createExecuteDdlMojo().executeMojoSpec();
+        createLoadDataMojo().executeMojoSpec();
+        getLog().info("スキーマのインポートを終了しました");
+    }
+
+    private ExecuteDdlMojo createExecuteDdlMojo() {
+        ExecuteDdlMojo mojo = new ExecuteDdlMojo();
+        copyParameter(mojo);
+
+        mojo.setLog(getLog());
+        mojo.ddlDirectory = new File(inputDirectory, DDL_DIR_NAME);
+        mojo.extraDdlDirectory = new File(inputDirectory, EXTRADDL_DIR_NAME);
+
+        return mojo;
+    }
+
+    private LoadDataMojo createLoadDataMojo() {
+        LoadDataMojo mojo = new LoadDataMojo();
+        copyParameter(mojo);
+
+        mojo.setLog(getLog());
+        mojo.dataDirectory = new File(inputDirectory, DATA_DIR_NAME);
+        mojo.specifiedEncodingFiles = specifiedEncodingFiles;
+
+        return mojo;
+    }
+
+    private void allExtract(JarFile jar, String destDir) throws IOException {
+        Enumeration<JarEntry> enumEntries = jar.entries();
+        while (enumEntries.hasMoreElements()) {
+            java.util.jar.JarEntry file = (java.util.jar.JarEntry) enumEntries.nextElement();
+            java.io.File f = new java.io.File(destDir + java.io.File.separator + file.getName());
+            if (file.isDirectory()) {
+                f.mkdir();
+                continue;
+            }
+            java.io.InputStream is = jar.getInputStream(file);
+            java.io.FileOutputStream fos = new java.io.FileOutputStream(f);
+            while (is.available() > 0) {
+                fos.write(is.read());
+            }
+            fos.close();
+            is.close();
+        }
+    }
 
 }

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
@@ -18,13 +18,12 @@ package jp.co.tis.gsp.tools.dba.mojo;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.ArtifactResolutionRequest;
@@ -70,6 +69,16 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
 
     @Parameter(defaultValue = "${project.version}")
     protected String version;
+    
+    /*** LoadData Param **/
+    @Parameter
+    @SuppressWarnings("rawtypes")
+    protected Map specifiedEncodingFiles;
+
+    /*** jar内のディレクトリ構造 **/
+    private final String DDL_DIR_NAME = "ddlDirectory";
+    private final String EXTRADDL_DIR_NAME = "extraDdlDirecotry";
+    private final String DATA_DIR_NAME = "dataDirectory";
 
     @Override
 	protected void executeMojoSpec() throws MojoExecutionException, MojoFailureException {
@@ -88,26 +97,66 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
             }
         }
 
-        JarFile jarFile = JarFileUtil.create(new File(localRepository.getBasedir(),
-                localRepository.pathOf(artifact)));
-        String importFilename = StringUtils.defaultIfEmpty(dmpFile, schema + ".dmp");
-        InputStream is = null;
-        File importFile = new File(inputDirectory, importFilename);
-        JarEntry jarEntry = jarFile.getJarEntry(importFilename);
-        if (jarEntry == null)
-            throw new MojoExecutionException(importFilename + " is not found?");
+        // ddl及びdataディレクトリの取り出し
         try {
-            is = jarFile.getInputStream(jarEntry);
-            FileUtils.copyInputStreamToFile(is, importFile);
-        } catch(IOException e) {
+            if (!inputDirectory.exists()) {
+                try {
+                    FileUtils.forceMkdir(inputDirectory);
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Can't create dump output directory." + inputDirectory, e);
+                }
+            }
+
+            JarFile jarFile = JarFileUtil
+                    .create(new File(localRepository.getBasedir(), localRepository.pathOf(artifact)));
+            allExtract(jarFile, inputDirectory.getPath());
+        } catch (IOException e) {
             throw new MojoExecutionException("", e);
-        } finally {
-            IOUtils.closeQuietly(is);
         }
 
-		getLog().info("スキーマのインポートを開始します。:" + importFile);
-		dialect.importSchema(adminUser, adminPassword, schema, importFile);
-		getLog().info("スキーマのインポートを終了しました");
+        getLog().info("スキーマのインポートを開始します。:");
+        createExecuteDdlMojo().executeMojoSpec();
+        createLoadDataMojo().executeMojoSpec();
+        getLog().info("スキーマのインポートを終了しました");
 	}
+    private ExecuteDdlMojo createExecuteDdlMojo() {
+        ExecuteDdlMojo mojo = new ExecuteDdlMojo();
+        copyParameter(mojo);
 
+        mojo.setLog(getLog());
+        mojo.ddlDirectory = new File(inputDirectory, DDL_DIR_NAME);
+        mojo.extraDdlDirectory = new File(inputDirectory, EXTRADDL_DIR_NAME);
+
+        return mojo;
+    }
+
+    private LoadDataMojo createLoadDataMojo() {
+        LoadDataMojo mojo = new LoadDataMojo();
+        copyParameter(mojo);
+
+        mojo.setLog(getLog());
+        mojo.dataDirectory = new File(inputDirectory, DATA_DIR_NAME);
+        mojo.specifiedEncodingFiles = specifiedEncodingFiles;
+
+        return mojo;
+    }
+
+    private void allExtract(JarFile jar, String destDir) throws IOException {
+        Enumeration<JarEntry> enumEntries = jar.entries();
+        while (enumEntries.hasMoreElements()) {
+            java.util.jar.JarEntry file = (java.util.jar.JarEntry) enumEntries.nextElement();
+            java.io.File f = new java.io.File(destDir + java.io.File.separator + file.getName());
+            if (file.isDirectory()) {
+                f.mkdir();
+                continue;
+            }
+            java.io.InputStream is = jar.getInputStream(file);
+            java.io.FileOutputStream fos = new java.io.FileOutputStream(f);
+            while (is.available() > 0) {
+                fos.write(is.read());
+            }
+            fos.close();
+            is.close();
+        }
+    }
 }


### PR DESCRIPTION
- 機能説明
    - `export-schema`の実装をDBMS固有のダンプ処理から、ddlとcsvファイルをパッケージングした形式に変更する。
    - ddl & csvパッケージング形式の動作仕様
        - パラメータ
            - ddlが格納されているフォルダ
            - extraDDLが格納されているフォルダ
            - csv出力時のファイルエンコーディング（テーブル単位）
        - 生成処理
            1. DDLが格納されているフォルダを出力フォルダにコピー。
            1. extraDDLが格納されているフォルダを出力フォルダにコピー。
            1. 接続スキーマの各テーブルのデータをテーブル単位でcsvで出力フォルダに出力。
            1. 上記３つのフォルダをjarにパッケージする。  
  
  
        jar内部のレイアウト
        ```
  META-INF/
  ddlDirectory/
  extraDdlDirectory/
  dataDirectory/
        ```
pomの設定例
    ```xml
<execution>
	<id>export-schema</id>
	<phase>install</phase>
	<goals>
		<goal>export-schema</goal>
	</goals>
	<configuration>
		<ddlDirectory>target/ddl</ddlDirectory>
		<extraDdlDirectory>src/main/resources/extraddl</extraDdlDirectory>
		<specifiedEncodingTables>
			<CLIENT>UTF-8</CLIENT>
		</specifiedEncodingTables>
	</configuration>
</execution>
    ```