### PR TITLE
汎用モードのexport-schema/import-shcemaの制約事項とデータ型に関してドキュメントを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ DBMS固有のエクスポート機能を内部で呼び出すことで実現し�
 - CSVデータとDDLファイルをパッケージングすることで、スキーマのエクスポート処理を代替します。
 - CSVデータはgsp-dba-maven-pluginで出力します。DDL及び追加DDLは予め用意しておき、上記パラメータの`ddlDirectory`、`extraDdlDirectory`で場所を指定して下さい。
 - 出力されるCSVデータの文字エンコーディングはUTF-8です。
+- 扱えるデータ型及び制限事項は[こちら](doc/db-status.md#汎用exportschemaimportschemaの制限事項)を参照して下さい。
 - 以下に処理の流れを記載します。
     1. 指定スキーマのテーブルデータをCSVデータとして出力(to dataDirectory)。
     2. 上記パラメータ`ddlDirectory`配下のDDLファイルを収集します。
@@ -421,6 +422,7 @@ DBMS固有のエクスポート機能を内部で呼び出すことで実現し�
 
 #### <a name="importSchemaGeneral"> 汎用モード
 - DB2とSQLServerの場合は汎用モードのエクスポートとなるため、それを取り込むことでスキーマのインポートとなります。
+- 扱えるデータ型及び制限事項は[こちら](doc/db-status.md#汎用exportschemaimportschemaの制限事項)を参照して下さい。
 - 以下に処理の流れを記載します。
     1. 汎用モードで出力されたエクスポートjarファイルを取得、展開します。
     2. `ddlDirectory`及び`extraDdlDirectory`のDDLファイルを実行します。

--- a/doc/db-status.md
+++ b/doc/db-status.md
@@ -49,7 +49,7 @@
 | CHAR          | ○       | text                                                | - |
 | CLOB          | ×       | -                                                  | - |
 | DATE          | ○       | 1990-08-08                                          | - |
-| LONG          | ○       | 1234567890                                          | - |
+| LONG          | ×       | -                                                  | - |
 | LONG ROW      | ×       | -                                                  | - |
 | NCHAR         | ○       | text                                                | - |
 | NCLOB         | ×       | -                                                  | - |
@@ -167,3 +167,17 @@ IDENTITYを指定したカラムは使用できません。<br />
 | VARCHAR | ○ | text | - |
 | VARGRAPHIC | ○ | text | - |
 | XML | × | - | - |
+
+### 汎用ExportSchema/ImportSchemaの制限事項
+
+**H2**
+- OTHER型
+    - 利用不可。
+    
+**Oracle**
+- DATE型
+    - load-dataの制約上、OracleがDATE型で持つ時刻以下のデータは対象外となります。
+
+**SqlServer**
+- BINARY型
+    - 利用不可。


### PR DESCRIPTION
### 変更点

今回のテスト実施の際に発覚したload-dataで扱えるデータ型や汎用モードにおける注意事項などを記載。
具体的な記載内容は以下の通り。

- OracleのLong型をサポート対象外とした。
    - 原因は[ストリーム既にクローズ済みエラー問題](http://d.hatena.ne.jp/t_ita/20101108/1289210491)。
- H2
    - OTHER型は利用不可。[Javaシリアライズオブジェクト用](http://www.h2database.com/html/datatypes.html#other_type)みたいなのでユニットテストから除外した。
- SqlServer
    - BINARY型も汎用モードexport-schema/import-schemaのサポート対象外、ユニットテストから除外。