### PR TITLE
汎用ExportSchemaでサポートしていないデータ型が存在する場合のエラーメッセージの是正。

### DIFF
--- a/doc/db-status.md
+++ b/doc/db-status.md
@@ -170,6 +170,11 @@ IDENTITYを指定したカラムは使用できません。<br />
 
 ### 汎用ExportSchema/ImportSchemaの制限事項
 
+扱えるデータ型は[load-dataの対応状況](#load-dataの対応状況)に準拠します。  
+扱えないデータ型に関しては、ExportSchemaでそのカラムは出力されません。そのため、ImportSchemaをするとそのカラムはNULL値となります。
+
+また汎用ExportSchema/ImportSchema固有の制約として下記のものが存在します。
+
 **H2**
 - OTHER型
     - 利用不可。

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/Dialect.java
@@ -255,7 +255,7 @@ public abstract class Dialect {
 
             String type = rs.getString("TYPE_NAME");
             if (!isUsableType(type)) {
-                System.err.println(type + "型はサポートしていません。");
+                System.err.println("[WARN] " + tableName + "." + colName + "  " + type + "型はサポートしていません。");
                 return UN_USABLE_TYPE;
             }
             return rs.getInt("DATA_TYPE");


### PR DESCRIPTION
- レビュー指摘対応
    - 汎用ExportSchemaでサポートしていないデータ型が存在する場合のエラーメッセージの是正。
    - 汎用Export/ImportSchemaにおけるデータ型制約事項を追記。