### PR TITLE
postgresql bool column map to Java Boolean

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/ExtendedPostgreGenDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/ExtendedPostgreGenDialect.java
@@ -46,7 +46,7 @@ public class ExtendedPostgreGenDialect extends PostgreGenDialect {
                 "timestamptz", Timestamp.class, false, TemporalType.TIMESTAMP);
         
         private static ExtendedPostgreColumnType BOOL = new ExtendedPostgreColumnType(
-                "bool", boolean.class);
+                "bool", Boolean.class);
         
         public ExtendedPostgreColumnType(String dataType, Class<?> attributeClass) {
             super(dataType, attributeClass);

--- a/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
+++ b/src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes/java/gsp_entity.ftl
@@ -140,7 +140,7 @@ public class ${shortClassName}<#if shortSuperclassName??> extends ${shortSupercl
     <#if useAccessor>
     <@printAttrAnnotations tableName attr/>
     </#if>
-    public ${attr.attributeClass.simpleName} <#if attr.attributeClass.getSimpleName()?matches("[bB]oolean")>is<#else>get</#if>${attr.name?cap_first}() {
+    public ${attr.attributeClass.simpleName} <#if attr.attributeClass.getSimpleName()?matches("boolean")>is<#else>get</#if>${attr.name?cap_first}() {
         return ${attr.name};
     }
 


### PR DESCRIPTION
postgresqlにおいてboolのカラム（null可）の場合に、Javaのboolean型ではnullが取り扱えないため、boolのカラムについてはBooleanでEntityを生成すべき。

加えて、JavaではbooleanではなくBooleanの場合はアクセサはisXXX()ではなくgetXXX()でないと都合が悪い。

理想はboolのカラムについてnull可否が判定をして、Booleanとbooleanで生成わけれたらよいけどやってない。
