### PR TITLE
doc: MAVEN_OPTS の設定方法からコマンド例を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,11 +177,8 @@ pom.xmlに以下の設定を追加してください。
 
 #### MavenのJVMオプションに--add-opensを追加する
 
-以下のようにして、環境変数 `MAVEN_OPTS` に `--add-opens` の JVM オプションを追加してください。
-
-```
-> set MAVEN_OPTS=%MAVEN_OPTS% --add-opens java.base/java.lang=ALL-UNNAMED
-```
+MavenのJVMオプションに、 `--add-opens java.base/java.lang=ALL-UNNAMED` を設定してください。
+MavenのJVMオプションは、[環境変数 MAVEN_OPTS で設定できます](https://maven.apache.org/configure.html#maven_opts-environment-variable)。
 
 ### ゴール共通のパラメータ
 


### PR DESCRIPTION
`MAVEN_OPTS` の環境変数が定義されていない場合、 `%MAVEN_OPTS%` の部分は空文字にならずそのまま埋め込まれてしまうため、コマンド例を削除。