### PR TITLE
Dockerでテストできるようにする修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,9 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration combine.self="override">
-                                    <argLine>-Dfile.encoding=UTF-8 ${jacocoArgs}</argLine>
+                                    <!-- ロケールを日本にしないと、Docker上でテストしたときにOracleの日付の
+                                         デフォルト書式が変わってテストが失敗する -->
+                                    <argLine>-Dfile.encoding=UTF-8 ${jacocoArgs} -Duser.language=ja -Duser.country=JP</argLine>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -28,6 +28,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
@@ -247,9 +248,11 @@ public class MysqlDialect extends Dialect {
 					"-u", user,
 					"--password="+ password,
 					"-D", schema,
-					"-e", "\"source " + dumpFile.getAbsolutePath().replaceAll("\\\\", "/") + "\""
+					// -e の引数をダブルクォーテーションで括ると、
+					// Windows では問題ないが Linux 上で動かしたときにインポートができない
+					"-e", "source " + dumpFile.getAbsolutePath().replaceAll("\\\\", "/")
 			};
-            
+
             ProcessUtil.exec(args);
 
 		} catch (Exception e) {

--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/MysqlDialect.java
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/mojo/ImportSchemaMojo.java
@@ -109,7 +109,6 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
         	
             // jarの解凍
             extractJarAll(jarFile, inputDirectory.getAbsolutePath());
-            
         } catch(IOException e) {
             throw new MojoExecutionException("", e);
         }
@@ -158,8 +157,12 @@ public class ImportSchemaMojo extends AbstractDbaMojo {
             }
             java.io.InputStream is = jar.getInputStream(file);
             java.io.FileOutputStream fos = new java.io.FileOutputStream(f);
-            while (is.available() > 0) {
-                fos.write(is.read());
+
+            byte[] buffer = new byte[4096];
+            int size;
+
+            while ((size = is.read(buffer)) != -1) {
+                fos.write(buffer, 0, size);
             }
             fos.close();
             is.close();


### PR DESCRIPTION
## 修正内容

- [ファイルコピー処理の改善](https://github.com/coastland/gsp-dba-maven-plugin/commit/6f7b093159dd9fc80125bbfb2a03c0c83b17f1d3)
  - Docker でのテストに直接は関係ないが、ファイルコピーの処理があまりにも遅く実行に時間がかかりすぎるので修正を入れました
- [MySQL用の修正](https://github.com/coastland/gsp-dba-maven-plugin/commit/5925805949e6fb860fc7a430cc5898966b258c11)
  - MySQL の `--execute` オプションのパラメータをダブルクォーテーションで括ると、 Windows では問題ないが Linux 環境ではうまくパラメータが渡せないことがわかったため、ダブルクォーテーションを削除
  - Windows 上でもテストを動かし、ダブルクォーテーションが無くてもテストが通ることを確認
- [Oracle用の修正](https://github.com/coastland/gsp-dba-maven-plugin/commit/d289c24ad282ad4e2e90b59d4b68f97aaed3cb11)
  - Linux 上で動作させた場合、JDBC接続時のクライアント側のロケールが日本でなくなるため日付のフォーマットが `yyyy-MM-dd` ではない形になる
  - これにより、日本ロケールでの日付フォーマットを前提とした部分がエラーになる
  - テスト実行時のロケールをシステムプロパティで日本に固定することで、Linux環境上でもテストが通るように修正
- [SQL Server 用の修正](https://github.com/coastland/gsp-dba-maven-plugin/commit/20c39c86ffe5d91409bcb1acc22a8aee66f54fe0)
  - テストで実行する `sqlcmd` の起動方法が Windows 前提(コマンドプロンプトを使って起動)となっていたので、システムプロパティの `os.name` を見て実行環境に合わせて起動方法を切り替えるように修正
  - また、 `-v` オプションでスクリプトに変数を渡す方法が Windows 版でしかサポートされていないため、 Linux でも動く環境変数で渡す方法に統一
  - Windows 上でもテストが通ることを確認