### PR TITLE
test: MySQL8.0 JPA簡易検証のエラーを修正しました。

### DIFF
--- a/src/it/simple-jpa-test/src/test/resources/META-INF/persistence.xml
+++ b/src/it/simple-jpa-test/src/test/resources/META-INF/persistence.xml
@@ -39,7 +39,7 @@ http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
 		<jar-file>file:../classes</jar-file>
 		<properties>
 			<property name="javax.persistence.jdbc.driver" value="${mysql.jdbcDriver}" />
-			<property name="javax.persistence.jdbc.url" value="${mysql.url}" />
+			<property name="javax.persistence.jdbc.url" value="${mysql.reference.url}" />
 			<property name="javax.persistence.jdbc.user" value="${mysql.user}" />
 			<property name="javax.persistence.jdbc.password" value="${mysql.password}" />
 			<property name="eclipselink.ddl-generation" value="none" />

--- a/src/test/resources/jdbc_test.properties
+++ b/src/test/resources/jdbc_test.properties
@@ -25,6 +25,8 @@ mysql.adminUser=root
 mysql.adminPassword=password
 mysql.jdbcDriver=com.mysql.jdbc.Driver
 mysql.url=jdbc:mysql://localhost:3306/gsptest?useSSL=false&allowPublicKeyRetrieval=true
+# JPA?????(persistence.xml ?????XML??????????)
+mysql.reference.url=jdbc:mysql://localhost:3306/gsptest?useSSL=false&amp;allowPublicKeyRetrieval=true
 
 ## oracle
 oracle.schema=gsptest


### PR DESCRIPTION
以下のエラーを修正しました。

### エラー内容
mvn -P all_test -s ../maven/settings.xml clean invoker:run@mysql
の実行により、以下エラーとなる。

Tests in error: 
  jp.co.tis.gsp.jpatest.AppTest
  jp.co.tis.gsp.jpatest.AppTest

### 原因
jdbc_test.properties から
persistence.xml に渡される変数
mysql.url=jdbc:mysql://localhost:3306/gsptest?useSSL=false&allowPublicKeyRetrieval=true
に &(アンパサンド)が含まれており、正しくXML
が読み込めずエラーとなった。

### エラー対応
jdbc_test.properties にJPA簡易検証用に、XMLエスケープした変数を定義し、persistence.xmlに渡すよう修正。