### PR TITLE
古いEclipseLink JPAのページへのリンクを置換

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ pom.xmlに以下の設定を追加することでプラグインが使用でき�
 | outputDirectory            | ×     | DDLの出力ディレクトリ。デフォルトは、"target/ddl"。             |
 | lengthSemantics            | ×     | 長さセマンティクス。デフォルトはバイト。                        |
 | ddlTemplateFileDir         | ×     | プロジェクト固有のDDLテンプレートの配置ディレクトリをワークディレクトリからの相対パスで指定する。 |
-| allocationSize            | ×     | シーケンス生成SQLの増分値(INCREMENT BY)。デフォルトは"1"。<br /> allocationSizeと[generate-entity](#generate-entity)のallocationSizeの値はは一致させるようにして下さい。<br />(eclipseLink) https://wiki.eclipse.org/Introduction_to_EclipseLink_JPA_(ELUG)  |
+| allocationSize            | ×     | シーケンス生成SQLの増分値(INCREMENT BY)。デフォルトは"1"。<br /> allocationSizeと[generate-entity](#generate-entity)のallocationSizeの値はは一致させるようにして下さい。<br />(参考: Jakarta Persistence仕様 [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
 テンプレートをカスタマイズする際は、[generate-ddlで使用するテンプレートのカスタマイズ例](./recipe/custom-DdlTemplate.md)を参照してください。
 
 
@@ -388,7 +388,7 @@ MavenのJVMオプションは、[環境変数 MAVEN_OPTS で設定できます](
 | entityTemplate         | ×    | entity の自動生成テンプレート。デフォルトは、"java/gsp_entity.ftl"。|
 |javaFileDestDir        | ×      | 生成されたentityのjavaファイルを配置するディレクトリ|
 |templateFilePrimaryDir | ×      |entityTemplateまでのパス。デフォルトは、"src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes"。<br>使用例:ファイルまでのパスが"src/main/resource/template/gsp_template.ftlの場合、それぞれ <br> entityTemplate: gsp_template.ftl <br> templateFilePrimaryDir:src/main/resource/template <br> と設定する。|
-| allocationSize         | ×     | @SequenceGeneratorのallocationSize。デフォルトは"1"。 <br />上記allocationSizeと[generate-ddl](#generate-ddl)のallocationSizeは一致させるようにして下さい。 <br />(eclipseLink) https://wiki.eclipse.org/Introduction_to_EclipseLink_JPA_(ELUG) |
+| allocationSize         | ×     | @SequenceGeneratorのallocationSize。デフォルトは"1"。 <br />上記allocationSizeと[generate-ddl](#generate-ddl)のallocationSizeは一致させるようにして下さい。 <br />(参考: Jakarta Persistence仕様 [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
 | useJSR310         | ×     |JSR301に対応したEntityを生成するかどうか。デフォルトは、”false”。                   |
 テンプレートをカスタマイズする際は、[generate-entityで使用するテンプレートのカスタマイズ例](./recipe/custom-EntityTemplate.md)を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ pom.xmlに以下の設定を追加することでプラグインが使用でき�
 | outputDirectory            | ×     | DDLの出力ディレクトリ。デフォルトは、"target/ddl"。             |
 | lengthSemantics            | ×     | 長さセマンティクス。デフォルトはバイト。                        |
 | ddlTemplateFileDir         | ×     | プロジェクト固有のDDLテンプレートの配置ディレクトリをワークディレクトリからの相対パスで指定する。 |
-| allocationSize            | ×     | シーケンス生成SQLの増分値(INCREMENT BY)。デフォルトは"1"。<br /> allocationSizeと[generate-entity](#generate-entity)のallocationSizeの値はは一致させるようにして下さい。<br />(参考: Jakarta Persistence仕様 [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
+| allocationSize            | ×     | シーケンス生成SQLの増分値(INCREMENT BY)。デフォルトは"1"。<br /> allocationSizeと[generate-entity](#generate-entity)のallocationSizeの値はは一致させるようにして下さい。|
 テンプレートをカスタマイズする際は、[generate-ddlで使用するテンプレートのカスタマイズ例](./recipe/custom-DdlTemplate.md)を参照してください。
 
 
@@ -388,7 +388,7 @@ MavenのJVMオプションは、[環境変数 MAVEN_OPTS で設定できます](
 | entityTemplate         | ×    | entity の自動生成テンプレート。デフォルトは、"java/gsp_entity.ftl"。|
 |javaFileDestDir        | ×      | 生成されたentityのjavaファイルを配置するディレクトリ|
 |templateFilePrimaryDir | ×      |entityTemplateまでのパス。デフォルトは、"src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes"。<br>使用例:ファイルまでのパスが"src/main/resource/template/gsp_template.ftlの場合、それぞれ <br> entityTemplate: gsp_template.ftl <br> templateFilePrimaryDir:src/main/resource/template <br> と設定する。|
-| allocationSize         | ×     | @SequenceGeneratorのallocationSize。デフォルトは"1"。 <br />上記allocationSizeと[generate-ddl](#generate-ddl)のallocationSizeは一致させるようにして下さい。 <br />(参考: Jakarta Persistence仕様 [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
+| allocationSize         | ×     | @SequenceGeneratorのallocationSize。デフォルトは"1"。 <br />上記allocationSizeと[generate-ddl](#generate-ddl)のallocationSizeは一致させるようにして下さい。|
 | useJSR310         | ×     |JSR301に対応したEntityを生成するかどうか。デフォルトは、”false”。                   |
 テンプレートをカスタマイズする際は、[generate-entityで使用するテンプレートのカスタマイズ例](./recipe/custom-EntityTemplate.md)を参照してください。
 

--- a/en/README.md
+++ b/en/README.md
@@ -155,7 +155,7 @@ Configuration items(Y:required N:optional)
 | outputDirectory            | N     | Output directory of DDL. Default is "target/ddl".             |
 | lengthSemantics            | N     | Length semantics. The default is bytes.                        |
 | ddlTemplateFileDir         | N     | Specifies the directory where the project-specific DDL template is placed with a relative path from the work directory. |
-| allocationSize            |  N    | Increment value of sequence generation SQL (INCREMENT BY). Default is "1". <br /> The values of allocationSize and allocationSize of [generate-entity](#generate-entity) must be the same. <br />(Reference: Jakarta Persistence Specification [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
+| allocationSize            |  N    | Increment value of sequence generation SQL (INCREMENT BY). Default is "1". <br /> The values of allocationSize and allocationSize of [generate-entity](#generate-entity) must be the same. |
 To customize the template, see [Example of Template Customization for Use with Generate-ddl](./recipe/custom-DdlTemplate.md).
 
 
@@ -394,7 +394,7 @@ Configuration items(Y:required N:optional)
 | entityTemplate         |   N  | Auto-generated template of the entity. Default is "java/gsp_entity.ftl". |
 |javaFileDestDir        |    N   | Directory where the java file of the generated entity is placed |
 |templateFilePrimaryDir |    N   |Path up to entityTemplate. Default is "src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes". <br> Usage example: If the path to the file is "src/main/resource/template/gsp_template.ftl, configure <br> entityTemplate: gsp_template.ftl <br> templateFilePrimaryDir:src/main/resource/template <br> respectively. |
-| allocationSize         |   N   | allocationSize of @SequenceGenerator. Default is "1". <br /> Make sure that the above mentioned allocationSize and allocationSize of [generate-ddl](#generate-ddl) are the same. <br />(Reference: Jakarta Persistence Specification [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
+| allocationSize         |   N   | allocationSize of @SequenceGenerator. Default is "1". <br /> Make sure that the above mentioned allocationSize and allocationSize of [generate-ddl](#generate-ddl) are the same. |
 | useJSR310         |   N   | Whether to generate the entity corresponding to JSR301. Default is "false".                   |
 To customize the template, see [Example of Template Customization for Use with Generate-entity](./recipe/custom-EntityTemplate.md).
 

--- a/en/README.md
+++ b/en/README.md
@@ -155,7 +155,7 @@ Configuration items(Y:required N:optional)
 | outputDirectory            | N     | Output directory of DDL. Default is "target/ddl".             |
 | lengthSemantics            | N     | Length semantics. The default is bytes.                        |
 | ddlTemplateFileDir         | N     | Specifies the directory where the project-specific DDL template is placed with a relative path from the work directory. |
-| allocationSize            |  N    | Increment value of sequence generation SQL (INCREMENT BY). Default is "1". <br /> The values of allocationSize and allocationSize of [generate-entity](#generate-entity) must be the same. <br />(eclipseLink) https://wiki.eclipse.org/Introduction_to_EclipseLink_JPA_(ELUG)  |
+| allocationSize            |  N    | Increment value of sequence generation SQL (INCREMENT BY). Default is "1". <br /> The values of allocationSize and allocationSize of [generate-entity](#generate-entity) must be the same. <br />(Reference: Jakarta Persistence Specification [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
 To customize the template, see [Example of Template Customization for Use with Generate-ddl](./recipe/custom-DdlTemplate.md).
 
 
@@ -394,7 +394,7 @@ Configuration items(Y:required N:optional)
 | entityTemplate         |   N  | Auto-generated template of the entity. Default is "java/gsp_entity.ftl". |
 |javaFileDestDir        |    N   | Directory where the java file of the generated entity is placed |
 |templateFilePrimaryDir |    N   |Path up to entityTemplate. Default is "src/main/resources/org/seasar/extension/jdbc/gen/internal/generator/tempaltes". <br> Usage example: If the path to the file is "src/main/resource/template/gsp_template.ftl, configure <br> entityTemplate: gsp_template.ftl <br> templateFilePrimaryDir:src/main/resource/template <br> respectively. |
-| allocationSize         |   N   | allocationSize of @SequenceGenerator. Default is "1". <br /> Make sure that the above mentioned allocationSize and allocationSize of [generate-ddl](#generate-ddl) are the same. <br />(eclipseLink) https://wiki.eclipse.org/Introduction_to_EclipseLink_JPA_(ELUG) |
+| allocationSize         |   N   | allocationSize of @SequenceGenerator. Default is "1". <br /> Make sure that the above mentioned allocationSize and allocationSize of [generate-ddl](#generate-ddl) are the same. <br />(Reference: Jakarta Persistence Specification [11.1.48. SequenceGenerator Annotation](https://jakarta.ee/ja/specifications/persistence/3.1/jakarta-persistence-spec-3.1.pdf)) |
 | useJSR310         |   N   | Whether to generate the entity corresponding to JSR301. Default is "false".                   |
 To customize the template, see [Example of Template Customization for Use with Generate-entity](./recipe/custom-EntityTemplate.md).
 


### PR DESCRIPTION
JIRAチケット[JakartaEE10対応に伴い、JavaEE由来の文言の修正](https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-583?filter=allopenissues&jql=project%20%3D%20%22NAB%22%20AND%20statusCategory%20IN%20(%22To%20Do%22%2C%20%22In%20Progress%22)%20ORDER%20BY%20updated%20DESC)に関連し、
古いEclipseLink JPAのドキュメントへのリンクを置換した。

元のリンク（ https://wiki.eclipse.org/Introduction_to_EclipseLink_JPA_(ELUG) ）には`allocationSize`についての説明があったが、 Jakarta Persistence 3.1に対応するEclipseLink4.0のページ（ https://eclipse.dev/eclipselink/documentation/4.0/concepts/concepts.html#ENTITIES006 ）からは 説明が削除されていた。
元のリンクは`allocationSize`についての説明を補完する目的で添付されていたと見えるため、`allocationSize`についての説明が記載されているJakarta Persistence仕様のページを参照するように変更した。