### PR TITLE
domaの最新化

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,18 +134,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <source>17</source>
                         <target>17</target>
                         <encoding>UTF-8</encoding>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>org.seasar.doma</groupId>
-                                <artifactId>doma-processor</artifactId>
-                                <version>2.62.0</version>
-                            </path>
-                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,18 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.6.2</version>
                     <configuration>
                         <source>17</source>
                         <target>17</target>
                         <encoding>UTF-8</encoding>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.seasar.doma</groupId>
+                                <artifactId>doma-processor</artifactId>
+                                <version>2.62.0</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
             </plugins>
@@ -188,8 +195,8 @@
 
       <dependency>
         <groupId>org.seasar.doma</groupId>
-        <artifactId>doma</artifactId>
-        <version>2.16.0</version>
+        <artifactId>doma-core</artifactId>
+        <version>2.62.0</version>
         <scope>provided</scope>
       </dependency>
         <dependency>


### PR DESCRIPTION
Nablarchv6移行のため、domaを最新化しました。
Example-thymeleaf-webで動作確認を行い、問題ないことを確認しました。