### PR TITLE
SQL Server利用時に4,000文字を超えるVIEWを扱うと不完全な定義を取得してしまう問題に対応

### DIFF
--- a/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
+++ b/src/main/java/jp/co/tis/gsp/tools/dba/dialect/SqlserverDialect.java
@@ -182,7 +182,7 @@ public class SqlserverDialect extends Dialect {
      */
     @Override
     public String getViewDefinitionSql() {
-        return "SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?";
+        return "SELECT OBJECT_DEFINITION(object_id) AS view_definition FROM sys.views WHERE name = ? AND schema_id = SCHEMA_ID(?)";
     }
 
     private boolean existsUser(String adminUser, String adminPassword, String user) throws SQLException {


### PR DESCRIPTION
SQL Server利用時に、4,000文字を超えるVIEWを扱うと不完全なVIEW定義を取得してしまい、エンティティの生成（`generate-entity`）に失敗するという問題に対応。

動作確認として、以下を実施。

- 大量のダミーカラムを持つVIEWを作成して修正前は`generate-entity`に失敗し、修正後はエンティティの生成が可能になったことを確認
  - ダミーカラムは `$ seq 1000 | perl -wp -e 's!(.+)!id as id$1_foo_bar_hoge, !' | perl -wp -e 's!\r?\n!!g'` で定義し、2,6000文字を超えるVIEW定義とした
- SQL Server 2017、2019、2021でテストを実行し、既存のテストが問題なく動作することを確認