### PR TITLE
OSSRHからCentral Publisher Portalへ移行

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,23 +21,22 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
+    <developers>
+        <developer>
+            <id>coastland</id>
+            <name>coastland</name>
+            <email>nablarch@tis.co.jp</email>
+            <organization>coastland</organization>
+            <organizationUrl>https://github.com/coastland</organizationUrl>
+        </developer>
+    </developers>
     
     <scm>
         <connection>scm:git:git://github.com/coastland/gsp-dba-maven-plugin.git</connection>
         <developerConnection>scm:git:ssh://github.com/coastland/gsp-dba-maven-plugin.git</developerConnection>
         <url>https://github.com/coastland/gsp-dba-maven-plugin/tree/master</url>
     </scm>
-    
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh-snapshot</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <seasarVersion>2.4.46</seasarVersion>
@@ -472,7 +471,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <build>
                 <plugins>
                     <plugin>
@@ -514,6 +513,15 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>    


### PR DESCRIPTION
OSSRHのサービス終了に向けて、Maven Centralへのデプロイ方法をCentral Publisher Portalへ移行する。

主な変更点は以下のとおり。

- `distributionManagement`の削除
  - デプロイ先のidは`ossrh`から`central`となるが、`central`については明示的な定義は不要
  - SNAPSHOTリポジトリは使用していないので削除
- Profile名を`ossrh`から`central`に変更
  - 必須の変更ではないが、OSSRHの名称を残しても今後わかりにくくなるだけなので変更する
- Central Publishing Mavenプラグインを追加
  - `mvn deploy`コマンドでCentral Publisher Portalにデプロイするプラグイン
  - デプロイ時にのみ使うため、central Profileにのみ追加

上記まではOSSRHからの移行に必要となる変更だが、本リポジトリに関しては`pom.xml`に`developers`要素が不足していたため、合わせて追加している。

一時的に`version`を5.2.1に変更し、Central Publisher Potalへデプロイできることを確認。

```shell
$ mvn clean deploy -DskipTests -P central
```

![image](https://github.com/user-attachments/assets/e664503e-a4e8-487b-8824-228edaa22af0)
